### PR TITLE
Moved send of DeviceEquipped modevents

### DIFF
--- a/dist/scripts/source/zadEquipScript.psc
+++ b/dist/scripts/source/zadEquipScript.psc
@@ -228,8 +228,6 @@ Event OnEquipped(Actor akActor)
         StorageUtil.UnSetIntValue(akActor, "zad_TightenToken" + deviceInventory)
     EndIf
     OnEquippedPre(akActor, silent=silently)
-    libs.SendDeviceEquippedEvent(deviceName, akActor)
-    libs.SendDeviceEquippedEventVerbose(deviceInventory, zad_DeviousDevice, akActor)
     if !akActor.IsEquipped(DeviceInventory)
         akActor.EquipItem(DeviceInventory, false, true)
     EndIf    
@@ -260,6 +258,8 @@ Event OnEquipped(Actor akActor)
     EscapeLockpickAttemptsMade = 0
     menuDisable = false
 	DeviceWearer = akActor
+    libs.SendDeviceEquippedEvent(deviceName, akActor)
+    libs.SendDeviceEquippedEventVerbose(deviceInventory, zad_DeviousDevice, akActor)
 EndEvent
 
 Event OnUnequipped(Actor akActor)


### PR DESCRIPTION
Before this change, if a listener tried to extract properties of the rendered device (e.g. the device type, via a keyword check) in response to a DeviceEquipped modevent, they could not do so since the device was not actually equipped yet. I moved sending of DeviceEquipped modevents to after the rendered device is equipped, to guarantee that the device is actually equipped as listeners of the event would expect.