### PR TITLE
Utility.GetCurrentGameTime -> GameDaysPassed, collarPostureLeather property bugfix

### DIFF
--- a/dist/scripts/source/zadArmbinderEffect.psc
+++ b/dist/scripts/source/zadArmbinderEffect.psc
@@ -1,0 +1,88 @@
+ScriptName zadArmbinderEffect extends ActiveMagicEffect
+
+; Libraries
+zadLibs Property Libs Auto
+
+Perk Property zad_bc_wristXPPerk_1 Auto
+Perk Property zad_bc_wristXPPerk_2 Auto
+Perk Property zad_bc_wristXPPerk_3 Auto
+Perk Property zad_bc_wristXPPerk_4 Auto
+Perk Property zad_bc_wristXPPerk_5 Auto
+
+Float DeviceEquippedAt 
+Int MsgCounter
+
+Actor Me
+
+Event OnUpdate()
+	If Me == None
+		return
+	EndIf
+	RegisterForSingleUpdate(45)
+	If (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 2.0) && (MsgCounter == 0)
+		If Me == libs.PlayerRef
+			libs.Notify("You start to get used to being tied.")
+		EndIf
+		Me.AddPerk(zad_bc_wristXPPerk_1)		
+		MsgCounter += 1
+	EndIf
+	If (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 5.0) && (MsgCounter == 1)		
+		If Me == libs.PlayerRef
+			libs.Notify("Your wrist restraints don't hurt so much anymore.")		
+		EndIf
+		Me.AddPerk(zad_bc_wristXPPerk_2)
+		MsgCounter += 1
+	EndIf
+	If (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 12.0) && (MsgCounter == 2)
+		If Me == libs.PlayerRef
+			libs.Notify("You don't notice your wrist restraints anymore.")		
+		EndIf
+		Me.AddPerk(zad_bc_wristXPPerk_3)
+		MsgCounter += 1
+	EndIf
+	If (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 24.0) && (MsgCounter == 3)
+		If Me == libs.PlayerRef
+			libs.Notify("Your wrist restraints start to feel really comfortable!")
+		EndIf
+		Me.AddPerk(zad_bc_wristXPPerk_4)
+		MsgCounter += 1
+	EndIf
+	If (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 48.0) && (MsgCounter == 4)
+		If Me == libs.PlayerRef
+			libs.Notify("Wearing wrist restraints feels completely natural now!")		
+		EndIf
+		Me.AddPerk(zad_bc_wristXPPerk_5)
+		MsgCounter += 1
+	EndIf
+EndEvent
+
+Event OnSleepStart(float afSleepStartTime, float afDesiredSleepEndTime)				
+	float naplength = afDesiredSleepEndTime - afSleepStartTime	
+	DeviceEquippedAt += naplength	
+EndEvent
+	
+Event OnEffectStart(Actor akTarget, Actor akCaster)
+	libs.Log("OnEffectStart(): Heavy Bondage: " + akTarget.GetLeveledActorBase().GetName())
+	If Libs.Config.UseBoundCombatPerks == False
+		return
+	EndIf
+	Me = akTarget	
+	MsgCounter = 0	
+	DeviceEquippedAt = libs.GameDaysPassed.GetValue()	
+	If Me != libs.PlayerRef
+		return
+	EndIf
+	RegisterForSingleUpdate(45)
+	RegisterForSleep()
+EndEvent
+
+Event OnEffectFinish(Actor akTarget, Actor akCaster)
+    libs.Log("OnEffectFinish(): Heavy Bondage: " + akTarget.GetLeveledActorBase().GetName())
+    If akTarget == libs.PlayerRef
+        akTarget.RemovePerk(zad_bc_wristXPPerk_1)
+        akTarget.RemovePerk(zad_bc_wristXPPerk_2)
+        akTarget.RemovePerk(zad_bc_wristXPPerk_3)
+        akTarget.RemovePerk(zad_bc_wristXPPerk_4)
+        akTarget.RemovePerk(zad_bc_wristXPPerk_5)          
+    EndIf
+EndEvent

--- a/dist/scripts/source/zadEquipScript.psc
+++ b/dist/scripts/source/zadEquipScript.psc
@@ -624,7 +624,7 @@ bool Function RemoveDeviceWithKey(actor akActor = none, bool destroyDevice=false
 EndFunction
 
 Function ResetLockShield()
-    DeviceEquippedAt = Utility.GetCurrentGameTime()
+    DeviceEquippedAt = libs.GameDaysPassed.GetValue()
     SetLockShield()
 EndFunction
 
@@ -645,7 +645,7 @@ Bool Function CheckLockShield()
         return True
     EndIf
     Float HoursNeeded = LockShieldTimer
-    Float HoursPassed = (Utility.GetCurrentGameTime() - DeviceEquippedAt) * 24.0
+    Float HoursPassed = (libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24.0
     if HoursPassed > HoursNeeded
         return True
     Else
@@ -676,7 +676,7 @@ Bool Function CheckLockTimer()
         return True
     EndIf
     Float HoursNeeded = LockTimer
-    Float HoursPassed = (Utility.GetCurrentGameTime() - DeviceEquippedAt) * 24.0
+    Float HoursPassed = (libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24.0
     if HoursPassed > HoursNeeded
         return True
     Else
@@ -763,11 +763,11 @@ EndFunction
 Bool Function CanMakeUnlockAttempt()
     ; check if the character can make an unlock attempt.
     Float HoursNeeded = (UnlockCooldown * CalculateCooldownModifier(False))
-    Float HoursPassed = (Utility.GetCurrentGameTime() - LastUnlockAttemptAt) * 24.0
+    Float HoursPassed = (libs.GameDaysPassed.GetValue() - LastUnlockAttemptAt) * 24.0
     if HoursPassed > HoursNeeded
         If !DeviceKey || (DeviceKey && libs.PlayerRef.GetItemCount(DeviceKey) >= NumberOfKeysNeeded)
             ; don't reset the timer if the player doesn't even have keys, that's mean!
-            LastUnlockAttemptAt = Utility.GetCurrentGameTime()
+            LastUnlockAttemptAt = libs.GameDaysPassed.GetValue()
         EndIf
         return True
     Else
@@ -1049,9 +1049,9 @@ Bool Function CanMakeStruggleEscapeAttempt()
         return False
     EndIf    
     Float HoursNeeded = (EscapeCooldown * CalculateCooldownModifier(False))
-    Float HoursPassed = (Utility.GetCurrentGameTime() - LastStruggleEscapeAttemptAt) * 24.0
+    Float HoursPassed = (libs.GameDaysPassed.GetValue() - LastStruggleEscapeAttemptAt) * 24.0
     if HoursPassed > HoursNeeded
-        LastStruggleEscapeAttemptAt = Utility.GetCurrentGameTime()
+        LastStruggleEscapeAttemptAt = libs.GameDaysPassed.GetValue()
         return True
     Else
         Int HoursToWait = Math.Ceiling(HoursNeeded - HoursPassed)
@@ -1067,9 +1067,9 @@ Bool Function CanMakeCutEscapeAttempt()
         return False
     EndIf    
     Float HoursNeeded = (EscapeCooldown * CalculateCooldownModifier(False))
-    Float HoursPassed = (Utility.GetCurrentGameTime() - LastCutEscapeAttemptAt) * 24.0
+    Float HoursPassed = (libs.GameDaysPassed.GetValue() - LastCutEscapeAttemptAt) * 24.0
     if HoursPassed > HoursNeeded
-        LastCutEscapeAttemptAt = Utility.GetCurrentGameTime()
+        LastCutEscapeAttemptAt = libs.GameDaysPassed.GetValue()
         return True
     Else
         Int HoursToWait = Math.Ceiling(HoursNeeded - HoursPassed)
@@ -1086,9 +1086,9 @@ Bool Function CanMakeLockPickEscapeAttempt()
         return False
     EndIf    
     Float HoursNeeded = (EscapeCooldown * CalculateCooldownModifier(False))
-    Float HoursPassed = (Utility.GetCurrentGameTime() - LastLockPickEscapeAttemptAt) * 24.0
+    Float HoursPassed = (libs.GameDaysPassed.GetValue() - LastLockPickEscapeAttemptAt) * 24.0
     if HoursPassed > HoursNeeded
-        LastLockPickEscapeAttemptAt = Utility.GetCurrentGameTime()
+        LastLockPickEscapeAttemptAt = libs.GameDaysPassed.GetValue()
         return True
     Else
         Int HoursToWait = Math.Ceiling(HoursNeeded - HoursPassed)
@@ -1463,9 +1463,9 @@ Int Function RepairJammedLock(Float Chance)
     libs.log("Player is trying to repair " + DeviceName + ". Repair chance after modifiers: " + Chance +"%")
     ; check if the character can make a repair attempt
     Float HoursNeeded = (RepairCooldown * CalculateCooldownModifier(False))
-    Float HoursPassed = (Utility.GetCurrentGameTime() - LastRepairAttemptAt) * 24.0    
+    Float HoursPassed = (libs.GameDaysPassed.GetValue() - LastRepairAttemptAt) * 24.0    
     if HoursPassed > HoursNeeded
-        LastRepairAttemptAt = Utility.GetCurrentGameTime()
+        LastRepairAttemptAt = libs.GameDaysPassed.GetValue()
         If Utility.RandomFloat(0.0, 99.9) < (Chance * CalculateDifficultyModifier(True))
             libs.log("Player has repaired " + DeviceName)
             StorageUtil.SetIntValue(libs.playerref, "zad_Equipped" + libs.LookupDeviceType(zad_DeviousDevice) + "_LockJammedStatus", 0)

--- a/dist/scripts/source/zadEventCatsuit.psc
+++ b/dist/scripts/source/zadEventCatsuit.psc
@@ -74,7 +74,7 @@ Function PlayerIsInside()
 EndFunction
 
 float Function GetCurrentTimeOfDay()
-	float Time = Utility.GetCurrentGameTime()
+	float Time = libs.GameDaysPassed.GetValue()
 	Time -= Math.Floor(Time) ; Remove "previous in-game days passed" bit
 	Time *= 24 ; Convert from fraction of a day to number of hours
 	Return Time

--- a/dist/scripts/source/zadLibs.psc
+++ b/dist/scripts/source/zadLibs.psc
@@ -282,7 +282,7 @@ FormList Property zadStandardKeywords Auto
 Keyword Property questItemRemovalAuthorizationToken = None Auto
 FormList Property zadDeviceTypes Auto	; List of all main device type keywords. Useful for iterating functions.
 FormList Property zad_AlwaysSilent Auto	; Actors in this list will ALWAYS equip or unequip DD items silently.
-
+GlobalVariable Property GameDaysPassed Auto
 
 ; Rechargeable Soulgem Stuff
 Soulgem Property SoulgemEmpty Auto
@@ -838,7 +838,7 @@ Function InflateAnalPlug(actor akActor, int amount = 1)
 			log("Setting anal plug inflation to " + (currentVal))
 			zadInflatablePlugStateAnal.SetValueInt(currentVal)
 		EndIf	
-		LastInflationAdjustmentAnal = Utility.GetCurrentGameTime()
+		LastInflationAdjustmentAnal = GameDaysPassed.GetValue()
 	EndIf
 	SendInflationEvent(akActor, False, True, currentval)
 	Aroused.UpdateActorExposure(akActor, 15)
@@ -880,7 +880,7 @@ Function InflateVaginalPlug(actor akActor, int amount = 1)
 			log("Setting vaginal plug inflation to " + (currentVal))
 			zadInflatablePlugStateVaginal.SetValueInt(currentVal)
 		EndIf	
-		LastInflationAdjustmentVaginal = Utility.GetCurrentGameTime()
+		LastInflationAdjustmentVaginal = GameDaysPassed.GetValue()
 	EndIf
 	SendInflationEvent(akActor, True, True, currentval)
 	Aroused.UpdateActorExposure(akActor, 15)
@@ -941,7 +941,7 @@ Function DeflateVaginalPlug(actor akActor, int amount = 1)
 			log("Setting vaginal plug inflation to " + (currentVal))
 			zadInflatablePlugStateVaginal.SetValueInt(currentVal)
 		EndIf	
-		LastInflationAdjustmentVaginal = Utility.GetCurrentGameTime()	
+		LastInflationAdjustmentVaginal = GameDaysPassed.GetValue()	
 	EndIf
 	SendInflationEvent(akActor, True, False, currentval)
 EndFunction
@@ -962,7 +962,7 @@ Function DeflateAnalPlug(actor akActor, int amount = 1)
 			log("Setting anal plug inflation to " + (currentVal))
 			zadInflatablePlugStateAnal.SetValueInt(currentVal)
 		EndIf	
-		LastInflationAdjustmentAnal = Utility.GetCurrentGameTime()	
+		LastInflationAdjustmentAnal = GameDaysPassed.GetValue()	
 	EndIf
 	SendInflationEvent(akActor, False, False, currentval)
 EndFunction
@@ -1346,7 +1346,7 @@ Function UpdateExposure(actor akRef, float val, bool skipMultiplier=false)
 			Aroused.SetActorExposure(akRef, (newVal + 1) as int)
 		else 														
 			StorageUtil.SetFloatValue(akRef, "SLAroused.ActorExposure", newVal)
-			StorageUtil.SetFloatValue(akRef, "SLAroused.ActorExposureDate", Utility.GetCurrentGameTime())
+			StorageUtil.SetFloatValue(akRef, "SLAroused.ActorExposureDate", GameDaysPassed.GetValue())
 		endif
 		
 	Else

--- a/dist/scripts/source/zadNPCQuestScript.psc
+++ b/dist/scripts/source/zadNPCQuestScript.psc
@@ -16,7 +16,7 @@ Function DoRegisterGameTime()
             Debug.MessageBox("Libs is none in zadNPCQuestScript. Incomplete uninstall/upgrade attempt?")
             Debug.Trace("[Zad]: Libs is none in zadNPCQuestScript. Incomplete uninstall/upgrade attempt?")
         else
-            float duration = libs.Config.EventInterval - (Utility.GetCurrentGameTime() - LastUpdateTime)
+            float duration = libs.Config.EventInterval - (libs.GameDaysPassed.GetValue() - LastUpdateTime)
             if duration <= 0 || duration > libs.Config.EventInterval ; Sanity check
                 duration = libs.Config.EventInterval
             EndIf
@@ -42,7 +42,7 @@ Event OnUpdateGameTime()
     else
         IsProcessing = True
         libs.Log("ZadNpc::OnUpdateGameTime()")
-        LastUpdateTime = Utility.GetCurrentGameTime()
+        LastUpdateTime = libs.GameDaysPassed.GetValue()
         if !libs.GlobalEventFlag
             libs.Log("Event processing is currently disabled.")
         else

--- a/dist/scripts/source/zadTrainingEffect.psc
+++ b/dist/scripts/source/zadTrainingEffect.psc
@@ -1,0 +1,120 @@
+ScriptName zadTrainingEffect extends ActiveMagicEffect
+
+; Libraries
+zadLibs Property Libs Auto
+SexlabFramework Property Sexlab Auto
+
+Bool Property Terminate Auto
+actor Property Target Auto
+
+; Extend this function to set a day passed event.
+Function OnTrainingDayPassed(int daysRemaining)
+	if daysRemaining == 1
+		libs.NotifyPlayer("You hear a single chime originating from inside of you.")
+	Else
+		libs.NotifyPlayer("You hear a set of "+daysRemaining+" chimes originating from inside of you.")
+	EndIf
+EndFunction
+
+; Extend this function to set training completed event.
+Function OnTrainingComplete() 
+	libs.Log("The training plug within you lets out a chime, and begins to vibrate!")
+	ModDaysRemaining(7, maxRange=GetTrainingRange())
+	libs.VibrateEffect(Target, 5, 120, teaseOnly=false)
+EndFunction
+
+; Extend this function to set the maximum training duration.
+int Function GetTrainingRange()
+	return 7
+EndFunction
+
+; Extend this function to easily set your own criteria for violations.
+Event OnTrainingViolation(string eventName, string argString, float argNum, form sender)
+	libs.Log("OnTrainingViolation("+argString+")")
+	if argString == "SpellCast"
+		ModDaysRemaining(1, maxRange=GetTrainingRange())
+		libs.NotifyPlayer("Your mental reserves are dramatically drained as the plug punishes you.")
+		libs.PlayerRef.DamageAv("Magicka", 200)
+	EndIf
+EndEvent
+
+Function DoRegisterModEvent()
+	UnregisterForModEvent("TrainingViolation")
+	RegisterForModEvent("TrainingViolation", "OnTrainingViolation")
+EndFunction
+
+
+Event OnUpdateGameTime()
+	if !Terminate
+		DoRegister()
+	EndIf
+EndEvent
+
+float Function InitNextTickTime()
+	float ret = libs.GameDaysPassed.GetValue() + 1.0
+	StorageUtil.SetFloatValue(Target, "zad.NextTickTime", ret)
+	return ret
+EndFunction
+
+Function DoRegister()
+	float nextTime = StorageUtil.GetFloatValue(Target, "zad.NextTickTime", -1.0)
+	if nextTime == -1.0
+		nextTime = InitNextTickTime()
+	EndIf
+	libs.Log("DoRegister(Training):"+libs.GameDaysPassed.GetValue()+" / "+ nextTime)
+	if !Terminate && libs.GameDaysPassed.GetValue() >= nextTime
+		InitNextTickTime()
+		int daysRemaining = ModDaysRemaining(-1, maxRange=GetTrainingRange())
+		libs.Log("DoRegister(Training): Day passed. Days Remaining: "+daysRemaining +".")
+		if daysRemaining == 0
+			libs.Log("Player has completed training.")
+			OnTrainingComplete()
+		Else
+			OnTrainingDayPassed(daysRemaining)
+		EndIf
+	EndIf
+	RegisterForSingleUpdateGameTime(1.0)
+EndFunction
+		
+int Function ModDaysRemaining(int changeBy, int maxRange) 
+	int daysRemaining = StorageUtil.GetIntValue(Target, "zad.TrainingDaysRemaining", maxRange)
+	int newDaysRemaining = daysRemaining + changeBy
+	if newDaysRemaining <0
+		newDaysRemaining = 0
+	EndIf
+	if newDaysRemaining > maxRange
+		newDaysRemaining = maxRange
+	EndIf
+	InitNextTickTime()
+	libs.log("Days remaining was: "+daysRemaining+". Now set to "+newDaysRemaining+".")
+	StorageUtil.SetIntValue(Target, "zad.TrainingDaysRemaining", newDaysRemaining)
+	return newDaysRemaining
+EndFunction
+
+Event OnEffectStart(Actor akTarget, Actor akCaster)
+	Target = akTarget
+	if Target != libs.PlayerRef
+		libs.Log("OnEffectStart(Training): Not player, doing nothing.")
+	else
+		libs.Log("OnEffectStart(Training)")
+		Terminate = False
+		DoRegisterModEvent()
+		DoRegister()
+	EndIf
+EndEvent
+
+Event OnEffectFinish(Actor akTarget, Actor akCaster)
+	Terminate = True
+	UnregisterForModEvent("TrainingViolation")
+	UnregisterForUpdateGameTime()
+	libs.Log("OnEffectFinish(Training)")
+EndEvent
+
+
+Event OnLoad()
+	if Target == libs.PlayerRef
+		DoRegisterModEvent()
+		DoRegister()
+	Endif
+EndEvent
+

--- a/dist/scripts/source/zad_EffInflatablePlugsAnalScript.psc
+++ b/dist/scripts/source/zad_EffInflatablePlugsAnalScript.psc
@@ -1,0 +1,120 @@
+Scriptname zad_EffInflatablePlugsAnalScript extends activemagiceffect  
+
+zadLibs Property Libs Auto
+
+Actor Property target Auto Hidden
+bool Property Terminate Auto Hidden
+
+; Global properties are declared here for convenience
+Keyword Property loctypeplayerhome Auto
+Keyword Property LocTypeJail Auto
+Keyword Property LocTypeDungeon Auto
+Keyword Property LocSetCave Auto
+Keyword Property LocTypeDwelling Auto
+Keyword Property LocTypeCity Auto
+Keyword Property LocTypeTown Auto
+Keyword Property LocTypeHabitation Auto
+Keyword Property LocTypeDraugrCrypt Auto
+Keyword Property LocTypeDragonPriestLair Auto
+Keyword Property LocTypeBanditCamp Auto
+Keyword Property LocTypeFalmerHive Auto
+Keyword Property LocTypeVampireLair Auto
+Keyword Property LocTypeDwarvenAutomatons Auto
+Keyword Property LocTypeMilitaryFort Auto
+Keyword Property LocTypeMine Auto
+Keyword Property LocTypeInn Auto
+Keyword Property LocTypeHold Auto
+
+Function DoRegister()
+	if !Terminate && target
+		RegisterForSingleUpdate(30.0)
+	EndIf
+EndFunction
+
+Function DoStart()	
+	if !Terminate && target
+		RegisterForSingleUpdate(30.0)
+	EndIf
+EndFunction
+
+Function DoUnregister()
+	if !Terminate && target		
+		UnregisterForUpdate()
+	EndIf	
+EndFunction
+
+bool Function isInHomeorJail()
+	Location loc = libs.PlayerRef.GetCurrentLocation()
+    if loc != none && (loc.haskeyword(loctypeplayerhome) || loc.haskeyword(loctypejail) ) 
+        return true
+    endif    
+    return false
+endfunction
+
+bool Function isInCity()
+	Location loc = libs.PlayerRef.GetCurrentLocation()
+    if loc != none && (loc.haskeyword(loctypecity) || loc.haskeyword(loctypetown) || loc.haskeyword(loctypehabitation) || loc.haskeyword(loctypedwelling))        
+        return true
+    endif    
+    return false
+endfunction
+
+bool Function isInHold()  
+	Location loc = libs.PlayerRef.GetCurrentLocation() 
+    if !libs.PlayerRef.GetParentCell().IsInterior() && (loc == none || loc.haskeyword(loctypehold))
+        return true
+    endif    
+    return false
+endfunction
+
+Event OnUpdate()	
+	if !Terminate
+		If (libs.GameDaysPassed.GetValue() - libs.LastInflationAdjustmentAnal) * 24.0 > 5.0 && (libs.zadInflatablePlugStateAnal.GetValueInt() > 0)
+			libs.zadInflatablePlugStateAnal.SetValueInt(libs.zadInflatablePlugStateAnal.GetValueInt() - 1)
+			libs.notify("Your inflatable plugs lose some pressure...")
+			libs.LastInflationAdjustmentAnal = libs.GameDaysPassed.GetValue()
+			DoRegister()
+			return
+		EndIf
+		if !libs.playerRef.IsInCombat() && !libs.IsAnimating(libs.playerRef) && !libs.playerref.IsOnMount() && !libs.playerref.IsSwimming() && !isInHomeorJail() && (isInCity() || isInHold()) && !UI.IsMenuOpen("Dialogue Menu")
+			; look for people that 'accidentally' inflate the plugs
+			If Utility.RandomInt() < 25 && (libs.GameDaysPassed.GetValue() - libs.LastInflationAdjustmentAnal) * 24.0 > 1.0 ; can't happen more than once in a while
+				libs.log("Inflatable Plugs: Testing for valid NPC.")
+				Actor currenttest		
+				currenttest = Game.FindRandomActorFromRef(libs.playerRef, 350.0)
+				if currenttest && libs.ValidForInteraction(currenttest, genderreq = -1, creatureok = false, animalok = false, beastreaceok = true, elderok = true, guardok = true)
+					libs.notify(currenttest.GetActorBase().GetName() + " gives your plug pump a squeeze, inflating it inside you!")
+					libs.InflateRandomPlug(libs.playerref, 1)
+				ElseIf Utility.RandomInt() < 10 ; when there is nobody there, she has a small chance to do it herself:
+					libs.notify("You 'accidentally' give your plug pump a squeeze...")
+					libs.InflateRandomPlug(libs.playerref, 1)
+				EndIf
+			EndIf
+		EndIf
+		libs.Aroused.UpdateActorExposure(libs.PlayerRef, 2)
+	Else ; Avoid race condition		
+	EndIf	
+	DoRegister()
+EndEvent
+
+Event OnEffectStart(Actor akTarget, Actor akCaster)	
+	libs.Log("OnEffectStart(): Inflatable Plugs")
+	; the effect will not be used for NPCs.
+	If akTarget != libs.PlayerRef
+		return
+	EndIf
+	Target = akTarget
+	Terminate = False	
+	libs.zadInflatablePlugStateAnal.SetValueInt(0)
+	libs.LastInflationAdjustmentAnal = libs.GameDaysPassed.GetValue()
+	DoStart()
+EndEvent
+
+Event OnEffectFinish(Actor akTarget, Actor akCaster)
+	libs.Log("OnEffectFinish(): Inflatable Plugs")	
+	If akTarget != libs.PlayerRef
+		return
+	EndIf
+	Terminate = True
+	DoUnregister()
+EndEvent

--- a/dist/scripts/source/zad_EffInflateableVaginalPlugScript.psc
+++ b/dist/scripts/source/zad_EffInflateableVaginalPlugScript.psc
@@ -1,0 +1,120 @@
+Scriptname zad_EffInflateableVaginalPlugScript extends activemagiceffect  
+
+zadLibs Property Libs Auto
+
+Actor Property target Auto Hidden
+bool Property Terminate Auto Hidden
+
+; Global properties are declared here for convenience
+Keyword Property loctypeplayerhome Auto
+Keyword Property LocTypeJail Auto
+Keyword Property LocTypeDungeon Auto
+Keyword Property LocSetCave Auto
+Keyword Property LocTypeDwelling Auto
+Keyword Property LocTypeCity Auto
+Keyword Property LocTypeTown Auto
+Keyword Property LocTypeHabitation Auto
+Keyword Property LocTypeDraugrCrypt Auto
+Keyword Property LocTypeDragonPriestLair Auto
+Keyword Property LocTypeBanditCamp Auto
+Keyword Property LocTypeFalmerHive Auto
+Keyword Property LocTypeVampireLair Auto
+Keyword Property LocTypeDwarvenAutomatons Auto
+Keyword Property LocTypeMilitaryFort Auto
+Keyword Property LocTypeMine Auto
+Keyword Property LocTypeInn Auto
+Keyword Property LocTypeHold Auto
+
+Function DoRegister()
+	if !Terminate && target
+		RegisterForSingleUpdate(30.0)
+	EndIf
+EndFunction
+
+Function DoStart()	
+	if !Terminate && target
+		RegisterForSingleUpdate(30.0)
+	EndIf
+EndFunction
+
+Function DoUnregister()
+	if !Terminate && target		
+		UnregisterForUpdate()
+	EndIf	
+EndFunction
+
+bool Function isInHomeorJail()
+	Location loc = libs.PlayerRef.GetCurrentLocation()
+    if loc != none && (loc.haskeyword(loctypeplayerhome) || loc.haskeyword(loctypejail) ) 
+        return true
+    endif    
+    return false
+endfunction
+
+bool Function isInCity()
+	Location loc = libs.PlayerRef.GetCurrentLocation()
+    if loc != none && (loc.haskeyword(loctypecity) || loc.haskeyword(loctypetown) || loc.haskeyword(loctypehabitation) || loc.haskeyword(loctypedwelling))        
+        return true
+    endif    
+    return false
+endfunction
+
+bool Function isInHold()  
+	Location loc = libs.PlayerRef.GetCurrentLocation() 
+    if !libs.PlayerRef.GetParentCell().IsInterior() && (loc == none || loc.haskeyword(loctypehold))
+        return true
+    endif    
+    return false
+endfunction
+
+Event OnUpdate()	
+	if !Terminate
+		If (libs.GameDaysPassed.GetValue() - libs.LastInflationAdjustmentVaginal) * 24.0 > 5.0 && (libs.zadInflatablePlugStateVaginal.GetValueInt() > 0)
+			libs.zadInflatablePlugStateVaginal.SetValueInt(libs.zadInflatablePlugStateVaginal.GetValueInt() - 1)
+			libs.notify("Your inflatable plugs lose some pressure...")
+			libs.LastInflationAdjustmentVaginal = libs.GameDaysPassed.GetValue()
+			DoRegister()
+			return
+		EndIf
+		if !libs.playerRef.IsInCombat() && !libs.IsAnimating(libs.playerRef) && !libs.playerref.IsOnMount() && !libs.playerref.IsSwimming() && !isInHomeorJail() && (isInCity() || isInHold()) && !UI.IsMenuOpen("Dialogue Menu")
+			; look for people that 'accidentally' inflate the plugs
+			If Utility.RandomInt() < 25 && (libs.GameDaysPassed.GetValue() - libs.LastInflationAdjustmentVaginal) * 24.0 > 1.0 ; can't happen more than once in a while
+				libs.log("Inflatable Plugs: Testing for valid NPC.")
+				Actor currenttest		
+				currenttest = Game.FindRandomActorFromRef(libs.playerRef, 350.0)
+				if currenttest && libs.ValidForInteraction(currenttest, genderreq = -1, creatureok = false, animalok = false, beastreaceok = true, elderok = true, guardok = true)
+					libs.notify(currenttest.GetActorBase().GetName() + " gives your plug pump a squeeze, inflating it inside you!")
+					libs.InflateRandomPlug(libs.playerref, 1)
+				ElseIf Utility.RandomInt() < 10 ; when there is nobody there, she has a small chance to do it herself:
+					libs.notify("You 'accidentally' give your plug pump a squeeze...")
+					libs.InflateRandomPlug(libs.playerref, 1)				
+				EndIf
+			EndIf
+		EndIf
+		libs.Aroused.UpdateActorExposure(libs.PlayerRef, 2)
+	Else ; Avoid race condition
+	EndIf	
+	DoRegister()
+EndEvent
+
+Event OnEffectStart(Actor akTarget, Actor akCaster)	
+	libs.Log("OnEffectStart(): Inflatable Plugs")
+	; the effect will not be used for NPCs.
+	If akTarget != libs.PlayerRef
+		return
+	EndIf
+	Target = akTarget
+	Terminate = False	
+	libs.zadInflatablePlugStateVaginal.SetValueInt(0)
+	libs.LastInflationAdjustmentVaginal = libs.GameDaysPassed.GetValue()
+	DoStart()
+EndEvent
+
+Event OnEffectFinish(Actor akTarget, Actor akCaster)
+	libs.Log("OnEffectFinish(): Inflatable Plugs")	
+	If akTarget != libs.PlayerRef
+		return
+	EndIf
+	Terminate = True
+	DoUnregister()
+EndEvent

--- a/dist/scripts/source/zadcFurnitureScript.psc
+++ b/dist/scripts/source/zadcFurnitureScript.psc
@@ -172,7 +172,7 @@ Function RemoveEffects(Actor akActor)
 EndFunction
 
 Function SetLockShield()
-	LockShieldStartedAt = Utility.GetCurrentGameTime()
+	LockShieldStartedAt = libs.GameDaysPassed.GetValue()
 	If (LockShieldTimerMin > 0.0) && (LockShieldTimerMin <= LockShieldTimerMax)
 		LockShieldTimer = ((Utility.RandomFloat(LockShieldTimerMin, LockShieldTimerMax)) * CalculateCooldownModifier(False))
 	Else
@@ -185,7 +185,7 @@ Bool Function CheckLockShield()
 		return True
 	EndIf
 	Float HoursNeeded = LockShieldTimer
-	Float HoursPassed = (Utility.GetCurrentGameTime() - LockShieldStartedAt) * 24.0
+	Float HoursPassed = (libs.GameDaysPassed.GetValue() - LockShieldStartedAt) * 24.0
 	if HoursPassed > HoursNeeded
 		return True
 	Else		
@@ -200,7 +200,7 @@ Function CheckSelfBondageRelease()
 		return 
 	EndIf
 	Float HoursNeeded = SelfBondageReleaseTimer
-	Float HoursPassed = (Utility.GetCurrentGameTime() - ReleaseTimerStartedAt) * 24.0
+	Float HoursPassed = (libs.GameDaysPassed.GetValue() - ReleaseTimerStartedAt) * 24.0
 	if HoursPassed > HoursNeeded
 		if user == libs.PlayerRef
 			libs.notify("The timed lock clicks open and frees you from the device!", messageBox = true)
@@ -324,8 +324,8 @@ Function LockActor(actor act)
 	EndIf			
 	clib.StoreDevice(user, self)
 	SetLockShield()	
-	DeviceEquippedAt = Utility.GetCurrentGameTime()
-	ReleaseTimerStartedAt = Utility.GetCurrentGameTime()
+	DeviceEquippedAt = libs.GameDaysPassed.GetValue()
+	ReleaseTimerStartedAt = DeviceEquippedAt
 	If ForceTimer
 		isSelfBondage = True
 	EndIf
@@ -415,9 +415,9 @@ EndEvent
 Bool Function CanMakeUnlockAttempt()
 	; check if the character can make an unlock attempt.
 	Float HoursNeeded = (UnlockCooldown * CalculateCooldownModifier(False))
-	Float HoursPassed = (Utility.GetCurrentGameTime() - LastUnlockAttemptAt) * 24.0
+	Float HoursPassed = (libs.GameDaysPassed.GetValue() - LastUnlockAttemptAt) * 24.0
 	if HoursPassed > HoursNeeded
-		LastUnlockAttemptAt = Utility.GetCurrentGameTime()
+		LastUnlockAttemptAt = libs.GameDaysPassed.GetValue()
 		return True
 	Else
 		Int HoursToWait = Math.Ceiling(HoursNeeded - HoursPassed)
@@ -757,7 +757,7 @@ Bool Function PasserbyAction()
 	If !AllowPasserbyAction || !User.Is3DLoaded() || User.GetParentCell() != Libs.PlayerRef.GetParentCell() || clib.IsAnimating(user)
 		return false
 	EndIf	
-	If ((Utility.GetCurrentGameTime() - LastPasserbyEventAt) * 24) < PasserbyCooldown
+	If ((libs.GameDaysPassed.GetValue() - LastPasserbyEventAt) * 24) < PasserbyCooldown
 		return false
 	EndIf	
 	if SexAnimations.Length == 0 || !clib.GetIsFemale(User)
@@ -830,7 +830,7 @@ Event OnDDCSLEnd(int tid, bool hasPlayer)
 	if !Userfound
 		return
 	endif
-	LastPasserbyEventAt = Utility.GetCurrentGameTime()
+	LastPasserbyEventAt = libs.GameDaysPassed.GetValue()
 	UnRegisterForModEvent("AnimationEnd")
 	User.SetDoingFavor(False)
     If User == libs.PlayerRef
@@ -1118,9 +1118,9 @@ EndFunction
 Bool Function CanMakeStruggleEscapeAttempt()
 	; right now we allow escape attempts regardless of which DD devices are worn
 	Float HoursNeeded = (EscapeCooldown * CalculateCooldownModifier(False))
-	Float HoursPassed = (Utility.GetCurrentGameTime() - LastStruggleEscapeAttemptAt) * 24.0
+	Float HoursPassed = (libs.GameDaysPassed.GetValue() - LastStruggleEscapeAttemptAt) * 24.0
 	if HoursPassed > HoursNeeded
-		LastStruggleEscapeAttemptAt = Utility.GetCurrentGameTime()
+		LastStruggleEscapeAttemptAt = libs.GameDaysPassed.GetValue()
 		return True
 	Else
 		Int HoursToWait = Math.Ceiling(HoursNeeded - HoursPassed)
@@ -1138,9 +1138,9 @@ EndFunction
 Bool Function CanMakeBreakEscapeAttempt()	
 	; right now we allow escape attempts regardless of which DD devices are worn
 	Float HoursNeeded = (EscapeCooldown * CalculateCooldownModifier(False))
-	Float HoursPassed = (Utility.GetCurrentGameTime() - LastBreakEscapeAttemptAt) * 24.0
+	Float HoursPassed = (libs.GameDaysPassed.GetValue() - LastBreakEscapeAttemptAt) * 24.0
 	if HoursPassed > HoursNeeded
-		LastBreakEscapeAttemptAt = Utility.GetCurrentGameTime()
+		LastBreakEscapeAttemptAt = libs.GameDaysPassed.GetValue()
 		return True
 	Else
 		Int HoursToWait = Math.Ceiling(HoursNeeded - HoursPassed)
@@ -1158,9 +1158,9 @@ EndFunction
 Bool Function CanMakeLockPickEscapeAttempt()	
 	; right now we allow escape attempts regardless of which DD devices are worn
 	Float HoursNeeded = (EscapeCooldown * CalculateCooldownModifier(False))
-	Float HoursPassed = (Utility.GetCurrentGameTime() - LastLockPickEscapeAttemptAt) * 24.0
+	Float HoursPassed = (libs.GameDaysPassed.GetValue() - LastLockPickEscapeAttemptAt) * 24.0
 	if HoursPassed > HoursNeeded
-		LastLockPickEscapeAttemptAt = Utility.GetCurrentGameTime()
+		LastLockPickEscapeAttemptAt = libs.GameDaysPassed.GetValue()
 		return True
 	Else
 		Int HoursToWait = Math.Ceiling(HoursNeeded - HoursPassed)

--- a/dist/scripts/source/zadclibs.psc
+++ b/dist/scripts/source/zadclibs.psc
@@ -201,7 +201,7 @@ Bool Function SetTimedRelease(ObjectReference FurnitureDevice, Int Hours, Bool R
 		fs.isSelfBondage = True
 		fs.SelfBondageReleaseTimer = Hours
 		if ResetStartTime
-			fs.ReleaseTimerStartedAt = Utility.GetCurrentGameTime()
+			fs.ReleaseTimerStartedAt = libs.GameDaysPassed.GetValue()
 		EndIf
 	EndIf
 EndFunction


### PR DESCRIPTION
Add: CK property GameDaysPassed in zadLibs pointing to GameDaysPassed[0x39] GlobalVariable
Replace: Utility.GetCurrentGameTime() calls with faster GameDaysPassed GlobalVariable
Fix: CK property collarPostureLeather in zadLibs didn't point to correct Inventory device

A patch with the needed changes to Devious Device - Integration.esm is on Discord