### PR TITLE
SLUTS, DDNG compatibility

### DIFF
--- a/dist/SKSE/Plugins/DeviousDevices.ini
+++ b/dist/SKSE/Plugins/DeviousDevices.ini
@@ -18,8 +18,8 @@ bEquipFilterModeMenu = true
 asWhitelist = 3BBB Body, SMP
 # Array of keywords which will be used to whitelist food items from filter
 # All whitelisted items can be eaten even when gagged
-# Default: Skooma
-asWhitelistFood = Skooma
+# Default: Skooma, SLUTS_VendorItemLotion
+asWhitelistFood = Skooma, SLUTS_VendorItemLotion
 # Changing this to 'false' will prevent player from equipping spells when player
 bEquipSpell = true
 # Changing this to 'false' will prevent player from equipping shouts when gagged (ring and panel gags can still allow shouts to work)


### PR DESCRIPTION
The latest update in SLUTS adds a potion which should be consumable while gagged, I just added the keyword these potions use to the white list. Lmk if there is a different way this should be done (just following krzp advice here)