### PR TITLE
SelectValidDDAnimations will take creature races into account when selecting animation by Taki17

### DIFF
--- a/dist/scripts/source/zadBQ00.psc
+++ b/dist/scripts/source/zadBQ00.psc
@@ -585,7 +585,16 @@ sslBaseAnimation[] function SelectValidAnimations(sslThreadController Controller
 		libs.log("Suppressed SexLab animations with tags: " + suppressString)
 	Else
 		;just try to find any SexLab animation that fits our conditions
-		Sanims = SexLab.GetAnimationsByTags(ActorCount, tagString, suppressString, True)
+		;handle creature tags
+		Int[] Genders = libs.SexLab.GenderCount(Controller.Positions)
+		;check if there are creatures in the array
+		If (Genders[2] + Genders[3]) < 1
+			;no creatures
+			Sanims = SexLab.GetAnimationsByTags(actorCount, tagString, suppressString, True)
+		Else
+			;yes creatures
+			Sanims = Sexlab.GetCreatureAnimationsByActorsTags(actorCount, Controller.Positions, tagString, suppressString, True)
+		EndIf
 		libs.log("Selecting SexLab animations with number of actors: " + ActorCount)
 		libs.log("Selecting SexLab animations with tag string: " + tagString)
 		libs.log("Selecting SexLab animations with suppress string: " + suppressString)


### PR DESCRIPTION
The implementation for selecting a fitting animation that matches the races of the creatures involved in the scene has been missing from SelectValidDDAnimations, and was only present in SelectValidAnimations. The same logic has been added the issue addressed.