### PR TITLE
Contraptions: Furniture faction

### DIFF
--- a/dist/scripts/source/zadcFurnitureScript.psc
+++ b/dist/scripts/source/zadcFurnitureScript.psc
@@ -38,6 +38,7 @@ Package[] Property StrugglePoseArmbinder Auto			; Packages containing the specia
 Package[] Property BoundPoseYoke Auto					; Packages containing special poses for yokes.
 Package[] Property StrugglePoseYoke Auto				; Packages containing the special struggle poses for yokes.
 Armor[] Property EquipDevices Auto						; List of DD devices or regular armor that will get equipped when an actor enters a device.
+Faction Property zadc_Faction_FurnitureUser Auto        ; Faction to be set on the user when he enters the furniture. Will be remove when the actor leaves the device. Can be used to detect actor state in Papyrus Conditions
 
 Key Property deviceKey  Auto               				; Key type to unlock this device
 Bool Property DestroyKey = False Auto 					; If set to true, the key(s) will be destroyed when the device is unlocked or escaped from.
@@ -349,6 +350,9 @@ Function LockActor(actor act)
 		SendDeviceEvent(True)
 	EndIf
 	AntiCL(user)
+	if zadc_Faction_FurnitureUser
+		user.AddToFaction(zadc_Faction_FurnitureUser)
+	endif
 EndFunction
 
 Function UnlockActor()
@@ -385,6 +389,9 @@ Function UnlockActor()
 		If SendDeviceModEvents
 			SendDeviceEvent(False)
 		EndIf
+		if zadc_Faction_FurnitureUser
+			user.RemoveFromFaction(zadc_Faction_FurnitureUser)
+		endif
 	Else
 		; something went wrong - insert error handling here
 		return


### PR DESCRIPTION
Requirement:
I as a modder want to control the "actor is in device" state in the CK scene editor.

Solution:
Put the actor into a faction (similar to SexlabAnimatedFaction), so state can be controlled by a Papyrus condition
