### PR TITLE
Made contraption passerby action suspend the struggle minigame, if that's running.

### DIFF
--- a/dist/scripts/source/zadcFurnitureScript.psc
+++ b/dist/scripts/source/zadcFurnitureScript.psc
@@ -755,6 +755,12 @@ Bool Function PasserbyAction()
         Else
             libs.notify(currenttest.GetLeveledActorBase().GetName() + " is going to take advantage of " + User.GetLeveledActorBase().GetName() + ".")
         EndIf
+		
+		; Suspend the struggle minigame, if it's running. It can be resumed again later by picking "struggle" from the menu.
+		if zadcNGEscapeMinigameQuest && zadcNGEscapeMinigameQuest.IsRunning() && !zadcNGEscapeMinigameQuest.IsSuspended()
+			zadcNGEscapeMinigameQuest.SuspendMinigame()
+		EndIf
+
 		SexScene(currenttest)
 		return true
 	EndIf


### PR DESCRIPTION
The new contraption struggle minigame and passerby action didn't play nice yet. I've made it so passerby action just suspends the minigame, this way they don't overlap and we don't get weird things happening. The minigame can just be resumed from the menu after the action is done.