### PR TITLE
New feature: optionally, wearing a blindfold prevents map use.

### DIFF
--- a/dist/scripts/source/zadConfig.psc
+++ b/dist/scripts/source/zadConfig.psc
@@ -15,7 +15,7 @@ String File = "../DD/DDConfig.json"
 
 ;Config Menu Script Version
 Int Function GetVersion()
-	Return 34
+	Return 35
 EndFunction
 
 ;Difficulty
@@ -57,6 +57,7 @@ Bool Property GagTooltip = True Auto Hidden
 Bool Property bootsSlowdownToggle = True Auto Hidden Conditional
 Bool Property mittensDropToggle = True Auto Hidden Conditional
 Int Property HobbleSkirtSpeedDebuff = 50 Auto Hidden 
+Bool Property BlindfoldBlockMapUse = False Auto Hidden
 
 ;Keys
 Int Property FurnitureNPCActionKey = 0xC9 Auto Hidden ; mapped to PgUp key
@@ -289,6 +290,7 @@ Event OnPageReset(String page)
 		AddToggleOptionST("HardcoreMittensST", "Hardcore Bondage Mittens", mittensDropToggle)
 		AddSliderOptionST("HobbleDressSlowST", "Hobble Dress Slowdown Strength", HobbleSkirtSpeedDebuff, "{0}")
 		AddEmptyOption()
+		AddToggleOptionST("BlindfoldBlockMapUseST", "Blindfolds Block Map Use", BlindfoldBlockMapUse)
 		AddMenuOptionST("BlindfoldModeST", "Blindfold Mode", blindfoldList[blindfoldMode])
 		If blindfoldMode < 3 ;all except dark fog
 			AddSliderOptionST("BlindfoldStrengthST", "Blindfold Effect Strength", blindfoldStrength, "{2}")
@@ -715,6 +717,20 @@ State ShowMinigameTutorialST
 	EndEvent
 	Event OnHighlightST()
 		SetInfoText("Whether or not tutorial messages are shown at the start of the contraption struggle escape minigame.")
+	EndEvent
+EndState
+
+State BlindfoldBlockMapUseST
+	Event OnSelectST()
+		BlindfoldBlockMapUse = !BlindfoldBlockMapUse
+		SetToggleOptionValueST(BlindfoldBlockMapUse)
+	EndEvent
+	Event OnDefaultST()
+		BlindfoldBlockMapUse = False
+		SetToggleOptionValueST(BlindfoldBlockMapUse)
+	EndEvent
+	Event OnHighlightST()
+		SetInfoText("When enabled, prevents the player from using the map while having a blindfold equipped.")
 	EndEvent
 EndState
 

--- a/dist/scripts/source/zadPlayerScript.psc
+++ b/dist/scripts/source/zadPlayerScript.psc
@@ -11,6 +11,9 @@ Armor Property zad_DeviceHider Auto
 zadGagVoices Property Voices Auto
 int[] voiceslots
 
+Keyword Property ArmorJewelry  Auto
+Keyword Property SexLabNoStrip  Auto
+
 Function InitGagSpeak(bool firsttime)
     Utility.Wait(2.0)
     If firsttime
@@ -87,6 +90,7 @@ Event OnPlayerLoadGame()
     endif
     Game.UpdateHairColor()
     RegisterEvents()
+	RegisterForMenu("MapMenu")
     InitGagSpeak(false)
 EndEvent
 
@@ -214,7 +218,6 @@ Event OnObjectEquipped(Form akBaseObject, ObjectReference akReference)
     ;Endif
 EndEvent
  
- 
 Event OnObjectUnequipped(Form akBaseObject, ObjectReference akReference)
     actor akActor = libs.PlayerRef
     if akBaseObject as Armor
@@ -229,6 +232,15 @@ Event OnObjectUnequipped(Form akBaseObject, ObjectReference akReference)
         EndIf
     EndIf    
 EndEvent
-Keyword Property ArmorJewelry  Auto
 
-Keyword Property SexLabNoStrip  Auto
+Event OnMenuOpen(String MenuName)
+	If libs.config.BlindfoldBlockMapUse && MenuName == "MapMenu" && libs.PlayerRef.WornHasKeyword(libs.zad_DeviousBlindfold)
+        ; Tiny wait, then disable abMenu player controls, which will close the map menu.
+		Utility.WaitMenuMode(0.05)
+		Game.DisablePlayerControls(false, false, false, false, false, true, false, false)
+        ; Another tiny wait, then re-enable the menu control.
+		Utility.WaitMenuMode(0.05)
+		Game.EnablePlayerControls(false, false, false, false, false, true, false, false)
+        libs.Notify("The blindfold you are wearing prevents you from reading your map.")
+	EndIf
+EndEvent


### PR DESCRIPTION
Added new feature: wearing a blindfold prevents use of the map. This is achieved by adding a listener for map menu events to zadPlayerScript that disables menu controls which closes the map before it opens fully. The menu controls are then re-enabled.

A new MCM option is added to toggle this feature on/off, with OFF being the default such that the new feature is opt-in.

Note that by disabling map use, this also effectively disables map-based fast travel while a blindfold is equipped.