### PR TITLE
Added missing RemoveFromFaction to contraption unlock.

### DIFF
--- a/dist/scripts/source/zadcFurnitureScript.psc
+++ b/dist/scripts/source/zadcFurnitureScript.psc
@@ -337,6 +337,7 @@ Function LockActor(actor act)
 	ApplyEffects(user)
 	ApplyDevices(user)	
 	user.AddToFaction(clib.zadcNGInContraptionFaction)
+	user.SetFactionRank(clib.zadcNGInContraptionFaction, 1)
 	RegisterForSingleUpdate(30)	
 	LastBreakEscapeAttemptAt = 0.0
 	LastStruggleEscapeAttemptAt = 0.0
@@ -386,6 +387,8 @@ Function UnlockActor()
 	RemoveEffects(user)
 	clib.ResetNiOverrideOverride(user)
 	RemoveDevices(user)
+	user.SetFactionRank(clib.zadcNGInContraptionFaction, 0)
+	user.RemoveFromFaction(clib.zadcNGInContraptionFaction)
 	;If ForceStripActor			
 	;	clib.RestoreOutfit(user)
 	;EndIf


### PR DESCRIPTION
Fixes the "in contraption" faction not getting cleared from the actor upon unlock.