### PR TITLE
Disabled footIK for actors in contraptions to improve feet placement

### DIFF
--- a/dist/scripts/source/zadcFurnitureScript.psc
+++ b/dist/scripts/source/zadcFurnitureScript.psc
@@ -314,6 +314,7 @@ Function LockActor(actor act)
 	Else
 		ActorUtil.AddPackageOverride(user, PickRandomPose(), 99)	
 	EndIf
+	user.SetAnimationVariableBool("bHumanoidFootIKDisable", true) ; so mr Howard and his footIK stops wrecking our animators' carefully calculated feet positions.
 	User.EvaluatePackage()			
 	self.disable()			
 	If act == libs.PlayerRef
@@ -367,6 +368,7 @@ Function UnlockActor()
 	UnregisterForUpdate()
 	UnregisterForAllControls()
 	user.StopTranslation()
+	user.SetAnimationVariableBool("bHumanoidFootIKDisable", false) ; Restore footIK
 	ActorUtil.RemovePackageOverride(user, CurrentStruggle)
 	ActorUtil.RemovePackageOverride(user, CurrentPose)
 	If user == Game.GetPlayer()


### PR DESCRIPTION
FootIK (Inverse Kinematics) is intended to correct feet placement for actors on slopes. However, with footIK enabled, feet often don't end up where the animator intended even on flat ground. Since actors in contraptions don't move and are _generally_ not on slopes, it is probably better to disable footIK. This PR disables footIK when actors enter contraptions, and restores it when they leave.