### PR TITLE
Update asWhitelistFood default values in config

### DIFF
--- a/dist/SKSE/Plugins/DeviousDevices.ini
+++ b/dist/SKSE/Plugins/DeviousDevices.ini
@@ -18,8 +18,8 @@ bEquipFilterModeMenu = true
 asWhitelist = 3BBB Body, SMP
 # Array of keywords which will be used to whitelist food items from filter
 # All whitelisted items can be eaten even when gagged
-# Default: Skooma, SLUTS_VendorItemLotion
-asWhitelistFood = Skooma, SLUTS_VendorItemLotion
+# Default: Skooma, Lotion
+asWhitelistFood = Skooma, Lotion
 # Changing this to 'false' will prevent player from equipping spells when gagged
 bEquipSpell = true
 # Changing this to 'false' will prevent player from equipping shouts when gagged (ring and panel gags can still allow shouts to work)


### PR DESCRIPTION
asWhiteFood takes raw names, from krzps initial explanation I thought it worked on keywords too. This fixes that misunderstanding