### PR TITLE
Bug fixes + Papyrus Optimizations

### DIFF
--- a/dist/scripts/source/zadArmbinderEffect.psc
+++ b/dist/scripts/source/zadArmbinderEffect.psc
@@ -15,42 +15,25 @@ Int MsgCounter
 Actor Me
 
 Event OnUpdate()
-	If Me == None
-		return
-	EndIf
 	RegisterForSingleUpdate(45)
-	If (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 2.0) && (MsgCounter == 0)
-		If Me == libs.PlayerRef
-			libs.Notify("You start to get used to being tied.")
-		EndIf
+	If (MsgCounter == 0) && (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 2.0)
+		libs.Notify("You start to get used to being tied.")
 		Me.AddPerk(zad_bc_wristXPPerk_1)		
 		MsgCounter += 1
-	EndIf
-	If (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 5.0) && (MsgCounter == 1)		
-		If Me == libs.PlayerRef
-			libs.Notify("Your wrist restraints don't hurt so much anymore.")		
-		EndIf
+	ElseIf (MsgCounter == 1) && (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 5.0)
+		libs.Notify("Your wrist restraints don't hurt so much anymore.")		
 		Me.AddPerk(zad_bc_wristXPPerk_2)
 		MsgCounter += 1
-	EndIf
-	If (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 12.0) && (MsgCounter == 2)
-		If Me == libs.PlayerRef
-			libs.Notify("You don't notice your wrist restraints anymore.")		
-		EndIf
+	ElseIf MsgCounter == 2 && (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 12.0)
+		libs.Notify("You don't notice your wrist restraints anymore.")		
 		Me.AddPerk(zad_bc_wristXPPerk_3)
 		MsgCounter += 1
-	EndIf
-	If (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 24.0) && (MsgCounter == 3)
-		If Me == libs.PlayerRef
-			libs.Notify("Your wrist restraints start to feel really comfortable!")
-		EndIf
+	ElseIf MsgCounter == 3 && (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 24.0)
+		libs.Notify("Your wrist restraints start to feel really comfortable!")
 		Me.AddPerk(zad_bc_wristXPPerk_4)
 		MsgCounter += 1
-	EndIf
-	If (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 48.0) && (MsgCounter == 4)
-		If Me == libs.PlayerRef
-			libs.Notify("Wearing wrist restraints feels completely natural now!")		
-		EndIf
+	ElseIf MsgCounter == 4 && (((libs.GameDaysPassed.GetValue() - DeviceEquippedAt) * 24) > 48.0)
+		libs.Notify("Wearing wrist restraints feels completely natural now!")		
 		Me.AddPerk(zad_bc_wristXPPerk_5)
 		MsgCounter += 1
 	EndIf
@@ -66,12 +49,12 @@ Event OnEffectStart(Actor akTarget, Actor akCaster)
 	If Libs.Config.UseBoundCombatPerks == False
 		return
 	EndIf
+	If akTarget != libs.PlayerRef
+		return
+	EndIf
 	Me = akTarget	
 	MsgCounter = 0	
 	DeviceEquippedAt = libs.GameDaysPassed.GetValue()	
-	If Me != libs.PlayerRef
-		return
-	EndIf
 	RegisterForSingleUpdate(45)
 	RegisterForSleep()
 EndEvent

--- a/dist/scripts/source/zadBQ00.psc
+++ b/dist/scripts/source/zadBQ00.psc
@@ -174,10 +174,7 @@ Function Maintenance()
 	; Finish initialization
 	Rehook()
 	; Make sure nothing got stuck on a previous play-through.
-	bool showCompass = true
-	if libs.playerRef.WornHasKeyword(libs.zad_DeviousBlindfold)
-		showCompass = false
-	EndIf
+	bool showCompass = !libs.playerRef.WornHasKeyword(libs.zad_DeviousBlindfold)
 	libs.ToggleCompass(showCompass)
 	libs.SetAnimating(libs.PlayerRef, false)
 	libs.StopVibrating(libs.PlayerRef)
@@ -424,26 +421,27 @@ sslBaseAnimation[] function SelectValidDDAnimations(Actor[] Actors, int actorCou
 		permitOral = False
 	EndIf
 
+	String suppressString = getSuppressString(permitOral, permitVaginal, permitAnal, permitBoobs, !HasBoundActors, suppresstag)
+
 	;we have bound anims only for 2 actors, restraints will be unequipped in case of more actors in a scene
 	;Animations need to be processed separately, since they are not registered in SexLab
-	If actorCount == 2 && HasBoundActors
-		;handle pet suits for 2 actor scenes, presently this is the only restraint type that needs animations called directly
-		If ( Actors[0].WornHasKeyword(libs.zad_DeviousPetSuit) || Actors[1].WornHasKeyword(libs.zad_DeviousPetSuit) )
-			libs.Log("Actor(s) wearing pet suit found. Trying to set up bound animation.")
-			Sanims = New sslBaseAnimation[1]
-			Sanims[0] = GetBoundAnim(Actors, permitOral, permitVaginal, permitAnal, permitBoobs)
-			If Sanims[0] == None
-				libs.log("Error: SelectValidDDAnimations couldn't find valid bound animations.")
-				Return Sanims
-			Else
-				Return Sanims
+	If actorCount == 2
+		If HasBoundActors
+			;handle pet suits for 2 actor scenes, presently this is the only restraint type that needs animations called directly
+			If ( Actors[0].WornHasKeyword(libs.zad_DeviousPetSuit) || Actors[1].WornHasKeyword(libs.zad_DeviousPetSuit) )
+				libs.Log("Actor(s) wearing pet suit found. Trying to set up bound animation.")
+				Sanims = New sslBaseAnimation[1]
+				Sanims[0] = GetBoundAnim(Actors, permitOral, permitVaginal, permitAnal, permitBoobs)
+				If Sanims[0] == None
+					libs.log("Error: SelectValidDDAnimations couldn't find valid bound animations.")
+					Return Sanims
+				Else
+					Return Sanims
+				Endif
 			Endif
-		Endif
-	Endif
-
-	String suppressString = getSuppressString(permitOral, permitVaginal, permitAnal, permitBoobs, !HasBoundActors, suppresstag)	
-	;we need to process private animations and masturbation as a special case and also not exclude opposite gender masturbation
-	If actorCount == 1 		
+		EndIf
+	ElseIf actorCount == 1
+		;we need to process private animations and masturbation as a special case and also not exclude opposite gender masturbation
 		libs.Log("Selecting masturbation animation.")
 		If HasArmbinderNonStrict(Actors[0]) ; she is wearing an armbinder
 			Sanims = New sslBaseAnimation[1]
@@ -575,7 +573,7 @@ sslBaseAnimation[] function SelectValidAnimations(sslThreadController Controller
 		tagString = "Solo," + tagString
 		If Controller.Positions[0].GetLeveledActorBase().GetSex() == 1
 			suppressString = "M," + suppressString
-		Elseif Controller.Positions[0].GetLeveledActorBase().GetSex() == 0
+		Else
 			suppressString = "F," + suppressString
 		EndIf
 	EndIf
@@ -901,15 +899,15 @@ Bool Function StartValidDDAnimation(Actor[] SexActors, bool forceaggressive = fa
 	TogglePanelGag(SexActors, False)
 	SkipFilter = False
 	Mutex = True
-	sslBaseAnimation[] SAnims
-	SAnims = SelectValidDDAnimations(SexActors, SexActors.Length, forceaggressive = forceaggressive, includetag = includetag, suppresstag = suppresstag)
-	If Sanims.Length <= 0 && nofallbacks
-		; no animations found, and the caller didn't want fallbacks. We can abort here.
-		libs.log("SelectValidDDAnimations failed to find any animations. Fallbacks disabled, aborting.")
-		Mutex = False
-		Return False
-	EndIf
+	sslBaseAnimation[] SAnims = SelectValidDDAnimations(SexActors, SexActors.Length, forceaggressive = forceaggressive, includetag = includetag, suppresstag = suppresstag)
 	If Sanims.Length <= 0
+		If nofallbacks
+			; no animations found, and the caller didn't want fallbacks. We can abort here.
+			libs.log("SelectValidDDAnimations failed to find any animations. Fallbacks disabled, aborting.")
+			Mutex = False
+			Return False
+		EndIf
+
 		; Hide chastity
 		libs.log("SelectValidDDAnimations failed to find any animations. Removing belts.")
 		StoreBelts(SexActors)
@@ -1327,22 +1325,24 @@ Event OnAnimationEnd(int threadID, bool HasPlayer)
 	libs.Log("OnAnimationEnd()")
 	sslThreadController Controller = Sexlab.ThreadSlots.GetController(threadID)
 	actor[] actors = controller.Positions
-	sslBaseAnimation previousAnim = controller.Animation
-	int numBeltedActors = CountBeltedActors(controller.Positions)
-	if (BoundMasturbation.Find(previousAnim.name) >=0 ) && actors.length == 1
-		if actors[0]!=libs.PlayerRef
-			libs.NotifyNPC(actors[0].GetLeveledActorbase().GetName() + " ceases her efforts, looking both frustrated and aroused.")
-		else
-			libs.NotifyPlayer("With a sigh, you realize that this is futile. You cannot possibly reach yourself, bound as you are. Your struggle has left you feeling even more aroused than when you began.", true)
+	If actors.length == 1
+		sslBaseAnimation previousAnim = controller.Animation
+		int numBeltedActors = CountBeltedActors(controller.Positions)
+		if (BoundMasturbation.Find(previousAnim.name) >=0 )
+			if actors[0]!=libs.PlayerRef
+				libs.NotifyNPC(actors[0].GetLeveledActorbase().GetName() + " ceases her efforts, looking both frustrated and aroused.")
+			else
+				libs.NotifyPlayer("With a sigh, you realize that this is futile. You cannot possibly reach yourself, bound as you are. Your struggle has left you feeling even more aroused than when you began.", true)
+			Endif
+		EndIf
+		If (numBeltedActors > 0) && previousAnim.name=="DDBeltedSolo"
+			if actors[0]!=libs.PlayerRef
+				libs.NotifyNPC(actors[0].GetLeveledActorbase().GetName() + " ceases her efforts, looking both frustrated and aroused.")
+			else
+				libs.NotifyPlayer("With a sigh, you realize that this is futile. You cannot fit even a single finger beneath the cruel embrace of the belt. Your struggle has left you feeling even more aroused than when you began.", true)
+			Endif
 		Endif
 	EndIf
-	If (numBeltedActors > 0) && previousAnim.name=="DDBeltedSolo" && actors.length==1
-		if actors[0]!=libs.PlayerRef
-			libs.NotifyNPC(actors[0].GetLeveledActorbase().GetName() + " ceases her efforts, looking both frustrated and aroused.")
-		else
-			libs.NotifyPlayer("With a sigh, you realize that this is futile. You cannot fit even a single finger beneath the cruel embrace of the belt. Your struggle has left you feeling even more aroused than when you began.", true)
-		Endif
-	Endif
 	TogglePanelGag(actors, True)
 	RetrieveHeavyBondage(actors)
 	RetrieveBelts(actors)

--- a/dist/scripts/source/zadBQ00.psc
+++ b/dist/scripts/source/zadBQ00.psc
@@ -1502,7 +1502,7 @@ Event OnDDIEquipDevice(Form akActor, String DeviceType)
 		libs.log("DDI ModEvent failed. No matching device found.")
 		return
 	Endif
-	armor rDevice = libs.GetRenderedDevice(iDevice)
+	armor rDevice = zadNativeFunctions.GetRenderDevice(iDevice) as Armor
 	libs.equipDevice(a, iDevice, rDevice, Kw, skipEvents = false, skipMutex = true)
 EndEvent
 
@@ -1515,7 +1515,7 @@ Event OnDDIRemoveDevice(Form akActor, String DeviceType)
 		libs.log("DDI ModEvent failed. No valid device string or no valid actor received.")
 		return
 	Endif
-	Armor iDevice = libs.GetWornDevice(a, kw)
+	Armor iDevice = zadNativeFunctions.GetWornDevice(a, kw)
 	If !iDevice
 		libs.log("DDI ModEvent device removal failed: " + a.GetLeveledActorBase().GetName() + " is not wearing the requested device type.")
 		return

--- a/dist/scripts/source/zadBQ00.psc
+++ b/dist/scripts/source/zadBQ00.psc
@@ -180,7 +180,7 @@ Function Maintenance()
 	libs.StopVibrating(libs.PlayerRef)
 	zadMagic.IsRunning = False
 	libs.DeviceMutex = false
-	libs.repopulateMutex = false
+	libs.GoToState("")
 	libs.lastRepopulateTime = 0.0
 	libs.zadNPCQuest.Maintenance()
 	libs.RepopulateNpcs()	
@@ -1079,7 +1079,7 @@ Function Logic(int threadID, bool HasPlayer)
 		sslBaseAnimation[] anims = SelectValidAnimations(Controller, originalActors.Length, previousAnim, PermitOral, PermitVaginal, PermitAnal, permitBoobs, noBindings)
 		;if we didn't get a valid animation, try fallbacks
 		If anims.Length <= 0
-			If anims.Length <= 0 && !permitVaginal
+			If !permitVaginal
 				;if it STILL doesn't work, we hide belts and plugs too
 				libs.Log("No bound animation found. Hiding chastity and plugs.")
 				StoreBelts(originalActors)
@@ -1356,7 +1356,7 @@ EndEvent
 
 function RelieveSelf()
     libs.Log("RelieveSelf()")
-    sslBaseAnimation[] anims = SexLab.GetAnimationsByTag(1, "Solo", "Masturbation", "F", requireAll=true)
+    sslBaseAnimation[] anims = SexLab.GetAnimationsByTags(1, "Solo,Masturbation,F", requireAll=true)
     if anims.length <=0
         libs.Warn("No masturbation animations available. Skipping scene.")
     else
@@ -1502,7 +1502,7 @@ Event OnDDIEquipDevice(Form akActor, String DeviceType)
 		libs.log("DDI ModEvent failed. No matching device found.")
 		return
 	Endif
-	armor rDevice = zadNativeFunctions.GetRenderDevice(iDevice) as Armor
+	armor rDevice = zadNativeFunctions.GetRenderDevice(iDevice)
 	libs.equipDevice(a, iDevice, rDevice, Kw, skipEvents = false, skipMutex = true)
 EndEvent
 

--- a/dist/scripts/source/zadBQ00.psc
+++ b/dist/scripts/source/zadBQ00.psc
@@ -1364,7 +1364,7 @@ function RelieveSelf()
         actors[0] = libs.PlayerRef
         SexLab.StartSex(actors, anims)
     endif
-    SetStage(100)
+    SetCurrentStageID(100)
 EndFunction
 
 Event OnSleepStart(float afSleepStartTime, float afDesiredSleepEndTime)	

--- a/dist/scripts/source/zadBlindfoldEffect.psc
+++ b/dist/scripts/source/zadBlindfoldEffect.psc
@@ -77,11 +77,7 @@ EndEvent
 
 Event OnUpdate()
     if Target == Libs.PlayerRef
-        if Terminate
-            libs.ToggleCompass(true)
-        Else
-            libs.ToggleCompass(false)
-        EndIf
+        libs.ToggleCompass(Terminate)
         DoRegister()
     EndIf
 EndEvent

--- a/dist/scripts/source/zadBlindfoldEffect.psc
+++ b/dist/scripts/source/zadBlindfoldEffect.psc
@@ -5,9 +5,9 @@ zadLibs Property Libs Auto
 ImagespaceModifier Property zad_BlindfoldModifier Auto
 ImagespaceModifier Property zad_BlindfoldLeeches Auto
 
-actor Property Target Auto
-Bool Property Terminate Auto
-Bool Property blinded Auto
+actor Target
+Bool Terminate
+Bool blinded
 
 float lastBlindfoldStrength = 0.0
 int lastdarkfogStrength = 0

--- a/dist/scripts/source/zadBoundCombatScript.psc
+++ b/dist/scripts/source/zadBoundCombatScript.psc
@@ -89,7 +89,7 @@ Function EvaluateAA(actor akActor)
 	endIf
 	
 	; Check if actor doesnt have drawn weapon, as calling animation event will otherwise break the character weapon state!
-	if !libs.IsAnimating(akActor) && !akActor.isDead() && !akActor.IsWeaponDrawn() && !akActor.getAV("Paralysis")
+	if !libs.IsAnimating(akActor) && !akActor.isDead() && !akActor.IsWeaponDrawn() && !akActor.GetActorValue("Paralysis")
 		Debug.SendAnimationEvent(akActor, "IdleForceDefaultState")
 	EndIf
 	
@@ -109,7 +109,7 @@ Function EvaluateAA(actor akActor)
 EndFunction
 
 Function ClearAA(actor akActor)
-	if akActor != libs.PlayerRef && !akActor.isDead() && !akActor.getAV("Paralysis")
+	if akActor != libs.PlayerRef && !akActor.isDead() && !akActor.GetActorValue("Paralysis")
 		akActor.EvaluatePackage()
 		if !libs.IsAnimating(akActor) 
 			Debug.SendAnimationEvent(akActor, "IdleForceDefaultState")

--- a/dist/scripts/source/zadBoundCombatScript.psc
+++ b/dist/scripts/source/zadBoundCombatScript.psc
@@ -146,27 +146,24 @@ EndFunction
 ; depreciated as of 4.1 - NPC feel like wearing our devices well enough, as soon as you code it right...
 
 Function Apply_NPC_ABC(actor akActor)
-	return
-	libs.Log("Apply_NPC_ABC( " + akActor.GetLeveledActorBase().GetName() + ", UnarmedDamage: " + akActor.GetActorValue("UnarmedDamage") + " )")
+;/	libs.Log("Apply_NPC_ABC( " + akActor.GetLeveledActorBase().GetName() + ", UnarmedDamage: " + akActor.GetActorValue("UnarmedDamage") + " )")
 	ActorUtil.AddPackageOverride(akActor, NPCBoundCombatPackageSandbox, 100)
 	StorageUtil.FormListAdd(libs.zadNPCQuest, "BoundCombatActors", akActor, true)
 	ActorUtil.AddPackageOverride(akActor, NPCBoundCombatPackage, 100)
-	akActor.AddSpell(ArmbinderDebuff)
+	akActor.AddSpell(ArmbinderDebuff)/;
 EndFunction
 
 
 Function Remove_NPC_ABC(actor akActor)
-	return
-	libs.Log("Removing NPC Bound Combat Package")
+;/	libs.Log("Removing NPC Bound Combat Package")
 	akActor.RemoveSpell(ArmbinderDebuff)
 	ActorUtil.RemovePackageOverride(akActor, NPCBoundCombatPackage)
-	StorageUtil.FormListRemove(libs.zadNPCQuest, "BoundCombatActors", akActor, true)
+	StorageUtil.FormListRemove(libs.zadNPCQuest, "BoundCombatActors", akActor, true)/;
 EndFunction
 
 
 Function CleanupNPCs()
-	return
-	int i = StorageUtil.FormListCount(libs.zadNPCQuest, "BoundCombatActors")
+;/	int i = StorageUtil.FormListCount(libs.zadNPCQuest, "BoundCombatActors")
 	while (i > 0)
 		i = i - 1
 		Actor akActor = StorageUtil.FormListGet(libs.zadNPCQuest, "BoundCombatActors", i) as Actor
@@ -175,7 +172,7 @@ Function CleanupNPCs()
 		ElseIf libs.IsValidActor(akActor) && !akActor.WornHasKeyword(libs.zad_DeviousHeavyBondage)
 			Remove_NPC_ABC(akActor)
 		EndIf
-	EndWhile
+	EndWhile/;
 EndFunction
 
 

--- a/dist/scripts/source/zadConfig.psc
+++ b/dist/scripts/source/zadConfig.psc
@@ -15,7 +15,7 @@ String File = "../DD/DDConfig.json"
 
 ;Config Menu Script Version
 Int Function GetVersion()
-	Return 35
+	Return 36
 EndFunction
 
 ;Difficulty
@@ -220,18 +220,13 @@ Event OnConfigInit()
 	SetupSoundDuration()
 	SetupSlotMasks()
 	SlotMaskOIDS = new int[128]
+	libs.GameDaysPassed = Game.GetForm(0x39) as GlobalVariable
 EndEvent
 
 Event OnVersionUpdate(Int newVersion)
 	libs.Log("OnVersionUpdate("+newVersion+"/"+CurrentVersion+")")
 	if newVersion != CurrentVersion
-		SlotMaskOIDS = new int[128]
-		SetupPages()
-		SetupDifficulties()
-		SetupEscapeDifficulties()
-		SetupBlindfolds()
-		SetupSoundDuration()
-		eventOIDs = new int[125]
+		OnConfigInit()
 		if !darkfogStrength
 			darkfogStrength = 500
 		EndIf

--- a/dist/scripts/source/zadConfig.psc
+++ b/dist/scripts/source/zadConfig.psc
@@ -807,7 +807,7 @@ State DarkFogStrengthST
 		SendModEvent("zadBlindfoldEffectUpdate")
 	EndEvent
 	Event OnDefaultST()
-		darkfogStrength = 500 as Int
+		darkfogStrength = 500
 		SetSliderOptionValueST(darkfogStrength, "{0}")
 		SendModEvent("zadBlindfoldEffectUpdate")
 	EndEvent

--- a/dist/scripts/source/zadConfig.psc
+++ b/dist/scripts/source/zadConfig.psc
@@ -1549,7 +1549,7 @@ Function ImportEvents()
 EndFunction
 
 Function ExportSettings()
-	JsonUtil.SetStringValue(File, "ExportLabel", Game.GetPlayer().GetLeveledActorBase().GetName()+" - "+Utility.GetCurrentRealTime() as int)
+	JsonUtil.SetStringValue(File, "ExportLabel", libs.PlayerRef.GetLeveledActorBase().GetName()+" - "+Utility.GetCurrentRealTime() as int)
 	JsonUtil.SetIntValue(File, "Version", GetVersion())
 	ExportDevicesUnderneath()
 	ExportEvents()

--- a/dist/scripts/source/zadDeviceLists.psc
+++ b/dist/scripts/source/zadDeviceLists.psc
@@ -155,7 +155,7 @@ Armor Function GetRandomDevice(LeveledItem akDeviceList)
         loc_nestedLL = loc_form As LeveledItem
         loc_armor = loc_form As Armor
     EndWhile
-    Return loc_form as Armor
+    Return loc_armor
 EndFunction
 
 

--- a/dist/scripts/source/zadDevicesUnderneathPlayerScript.psc
+++ b/dist/scripts/source/zadDevicesUnderneathPlayerScript.psc
@@ -1,9 +1,6 @@
 Scriptname zadDevicesUnderneathPlayerScript extends ReferenceAlias
 
 zadLibs Property libs Auto
-import zadNativeFunctions
-
-Bool Property Working Auto
 
 Event OnPlayerLoadGame()
     RegisterForSingleUpdate(3.0)

--- a/dist/scripts/source/zadDevicesUnderneathScript.psc
+++ b/dist/scripts/source/zadDevicesUnderneathScript.psc
@@ -1,13 +1,11 @@
 scriptname zadDevicesUnderneathScript extends Quest
 
 zadLibs Property libs Auto
-import zadNativeFunctions
 Armor Property zad_DeviceHider Auto
 ArmorAddon Property zad_DeviceHiderAA Auto
 
-int[] Property SlotMaskFilters Auto
-int[] Property SlotMaskUsage Auto
-int[] Property ShiftCache Auto
+int[] Property SlotMaskFilters Auto Hidden
+int[] Property ShiftCache Auto Hidden
 
 int Property SlotMask Auto ; Avoid repeated lookups
 
@@ -103,7 +101,7 @@ Function SyncSetting()
 EndFunction
 
 Function Maintenance()
-    SyncSetting()
+    ZadNativeFunctions.SyncSetting(SlotMaskFilters,Setting)
 EndFunction
 
 Function ApplySlotmask(Actor akActor)

--- a/dist/scripts/source/zadEquipScript.psc
+++ b/dist/scripts/source/zadEquipScript.psc
@@ -178,8 +178,7 @@ Event OnEquipped(Actor akActor)
         libs.Log("OnEquipped aborted - item is already worn.")
         ; no need to process if the item is already worn
         return
-    EndIf
-    if akActor.GetItemCount(deviceRendered) == 0 && akActor.WornHasKeyword(zad_DeviousDevice)
+    Elseif akActor.WornHasKeyword(zad_DeviousDevice)
         libs.Log("Wearing conflicting device type:" + zad_DeviousDevice)
         menuDisable = true
         akActor.UnequipItem(deviceInventory, false, true)
@@ -187,32 +186,34 @@ Event OnEquipped(Actor akActor)
     EndIf    
     bool silently = ShouldEquipSilently(akActor)
     ; check for device conflicts
-    If !silently && (IsEquipDeviceConflict(akActor) || IsEquipRequiredDeviceConflict(akActor))
-        menuDisable = true        
-        akActor.UnequipItem(deviceInventory, false, true)
-        return
-    EndIf    
-    If !silently && akActor == libs.playerref && !akActor.WornHasKeyword(zad_DeviousDevice) && akActor.GetItemCount(deviceRendered) == 0
-        Int msgChoice = zad_DeviceMsg.Show() ; display menu
-        if msgChoice != 0 ; Equip Device voluntarily
-            menuDisable = true
+    If !silently
+        If (IsEquipDeviceConflict(akActor) || IsEquipRequiredDeviceConflict(akActor))
+            menuDisable = true        
             akActor.UnequipItem(deviceInventory, false, true)
             return
-        Else            
-            StorageUtil.SetIntValue(akActor, "zad_Equipped" + libs.LookupDeviceType(zad_DeviousDevice) + "_ManipulatedStatus", 0)
-            If !DisableLockManipulation && libs.Config.UseItemManipulation && ( deviceRendered.HasKeyword(libs.zad_Lockable) || deviceInventory.HasKeyword(libs.zad_Lockable) ) && !deviceInventory.HasKeyword(libs.zad_QuestItem) && !deviceRendered.HasKeyword(libs.zad_QuestItem) && !deviceInventory.HasKeyword(libs.zad_BlockGeneric) && !deviceRendered.HasKeyword(libs.zad_BlockGeneric) 
-                Int Choice = 0
-                If zad_DD_OnPutOnDevice
-                    Choice = zad_DD_OnPutOnDevice.Show()
-                Else
-                    Choice = libs.zad_DD_OnPutOnDevice.Show()
-                EndIf
-                If Choice == 1
-                    StorageUtil.SetIntValue(akActor, "zad_Equipped" + libs.LookupDeviceType(zad_DeviousDevice) + "_ManipulatedStatus", 1)
+        EndIf    
+        If akActor == libs.playerref && !akActor.WornHasKeyword(zad_DeviousDevice) && akActor.GetItemCount(deviceRendered) == 0
+            Int msgChoice = zad_DeviceMsg.Show() ; display menu
+            if msgChoice != 0 ; Equip Device voluntarily
+                menuDisable = true
+                akActor.UnequipItem(deviceInventory, false, true)
+                return
+            Else            
+                StorageUtil.SetIntValue(akActor, "zad_Equipped" + libs.LookupDeviceType(zad_DeviousDevice) + "_ManipulatedStatus", 0)
+                If !DisableLockManipulation && libs.Config.UseItemManipulation && ( deviceRendered.HasKeyword(libs.zad_Lockable) || deviceInventory.HasKeyword(libs.zad_Lockable) ) && !deviceInventory.HasKeyword(libs.zad_QuestItem) && !deviceRendered.HasKeyword(libs.zad_QuestItem) && !deviceInventory.HasKeyword(libs.zad_BlockGeneric) && !deviceRendered.HasKeyword(libs.zad_BlockGeneric) 
+                    Int Choice = 0
+                    If zad_DD_OnPutOnDevice
+                        Choice = zad_DD_OnPutOnDevice.Show()
+                    Else
+                        Choice = libs.zad_DD_OnPutOnDevice.Show()
+                    EndIf
+                    If Choice == 1
+                        StorageUtil.SetIntValue(akActor, "zad_Equipped" + libs.LookupDeviceType(zad_DeviousDevice) + "_ManipulatedStatus", 1)
+                    EndIf
                 EndIf
             EndIf
-        EndIf
-    EndIf    
+        EndIf    
+    EndIf
     int filter = OnEquippedFilter(akActor, silent=silently)
     if filter >= 1
         if filter == 2
@@ -232,15 +233,19 @@ Event OnEquipped(Actor akActor)
         akActor.EquipItem(DeviceInventory, false, true)
     EndIf    
     akActor.EquipItem(DeviceRendered, true, true)
-    if akActor == libs.PlayerRef && !akActor.IsOnMount()
-        ; make it visible for the player in case the menu is open
-        akActor.QueueNiNodeUpdate()
-    elseif akActor != libs.PlayerRef && !akActor.IsOnMount() && deviceRendered.HasKeyword(libs.zad_DeviousHeavyBondage)
-        ; prevent a bug with straitjackets and elbowbinders not hiding NPC hands when equipping these items.        
-        akActor.UpdateWeight(0)
-    EndIf    
-    if akActor != libs.PlayerRef && (deviceRendered.HasKeyword(libs.zad_DeviousHeavyBondage) || deviceRendered.HasKeyword(libs.zad_DeviousHobbleSkirt))
-        libs.RepopulateNpcs()
+    if akActor == libs.PlayerRef
+        If !akActor.IsOnMount()
+            ; make it visible for the player in case the menu is open
+            akActor.QueueNiNodeUpdate()
+        EndIf
+    else
+        If !akActor.IsOnMount() && deviceRendered.HasKeyword(libs.zad_DeviousHeavyBondage)
+            ; prevent a bug with straitjackets and elbowbinders not hiding NPC hands when equipping these items.        
+            akActor.UpdateWeight(0)
+        EndIf
+        if (deviceRendered.HasKeyword(libs.zad_DeviousHeavyBondage) || deviceRendered.HasKeyword(libs.zad_DeviousHobbleSkirt))
+            libs.RepopulateNpcs()
+        EndIf    
     EndIf    
     OnEquippedPost(akActor)
     ResetLockShield()
@@ -1100,7 +1105,6 @@ EndFunction
 ; returns 0 when the escape attempt fails, 1 at success and -1 when no attempt was made due to cooldown
 Int Function Escape(Float Chance)
     StruggleScene(libs.PlayerRef)
-    Bool Success = False
     If Chance == 0.0
         ; no need to process, but returning here will prevent catastrophic failures when there is zero chance of success. We're not THAT mean!
         return 0
@@ -1149,27 +1153,23 @@ Float Function CalclulateCutSuccess()
     If CutDeviceEscapeChance > 0.0
         ; add 1% for every previous attempt
         result += EscapeCutAttemptsMade        
-        If Libs.PlayerRef.GetActorValue("OneHanded") > 25
-            result += 1.0
-        Endif
-        If Libs.PlayerRef.GetActorValue("OneHanded") > 50
-            result += 2.0
-        Endif
-        If Libs.PlayerRef.GetActorValue("OneHanded") > 75
+        Float akOneHanded = Libs.PlayerRef.GetActorValue("OneHanded")
+        If akOneHanded > 75
+            result += 6.0
+        ElseIf akOneHanded > 50
             result += 3.0
+        ElseIf akOneHanded > 25
+            result += 1.0
         Endif
         ; apply bonus for total successful escapes
-        Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue() as Int
-        If EscapesMade > 10
-            result += 1.0
-        Endif
-        If EscapesMade > 25
-            result += 1.0
-        Endif
-        If EscapesMade > 50
-            result += 1.0
-        Endif
+        Float EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue()
         If EscapesMade > 100
+            result += 4.0
+        ElseIf EscapesMade > 50
+            result += 3.0
+        ElseIf EscapesMade > 25
+            result += 2.0
+        ElseIf EscapesMade > 10
             result += 1.0
         Endif
     Endif
@@ -1274,37 +1274,35 @@ Function EscapeAttemptLockPick()
 EndFunction
 
 Bool Function HasValidLockPick()
-    Bool HasValidItem = false
     If AllowLockPick && libs.PlayerRef.GetItemCount(libs.Lockpick) > 0
         return true
     EndIf
     Int i = AllowedLockPicks.Length
-    While i > 0 && !HasValidItem
+    While i > 0
         i -= 1
         Form frm = AllowedLockPicks[i]
         If libs.playerRef.GetItemCount(frm) > 0
-            HasValidItem = True
+            return True
         EndIf
     EndWhile
-    return HasValidItem
+    return false
 EndFunction
 
 Bool Function DestroyLockPick()
-    Bool LockPickDestroyed = false
     If AllowLockPick && libs.PlayerRef.GetItemCount(libs.Lockpick) > 0
         libs.playerRef.RemoveItem(libs.Lockpick)
         return True
     EndIf
     Int i = AllowedLockPicks.Length
-    While i > 0 && !LockPickDestroyed
+    While i > 0
         i -= 1
         Form frm = AllowedLockPicks[i]
-        If libs.playerRef.GetItemCount(frm) > 0 && !(frm As Keyword)
+        If !(frm As Keyword) && libs.playerRef.GetItemCount(frm) > 0
             libs.playerRef.RemoveItem(frm)
-            LockPickDestroyed = True
+            return true
         EndIf
     EndWhile
-    return LockPickDestroyed
+    return false
 EndFunction
 
 Float Function CalclulateLockPickSuccess()
@@ -1313,27 +1311,23 @@ Float Function CalclulateLockPickSuccess()
     If LockPickEscapeChance > 0.0
         ; add 1% for every previous attempt
         result += EscapeLockPickAttemptsMade        
-        If Libs.PlayerRef.GetActorValue("Lockpicking") > 25
-            result += 1.0
-        Endif
-        If Libs.PlayerRef.GetActorValue("Lockpicking") > 50
-            result += 2.0
-        Endif
-        If Libs.PlayerRef.GetActorValue("Lockpicking") > 75
+        Float akLockpick = Libs.PlayerRef.GetActorValue("Lockpicking")
+        If akLockpick > 75
+            result += 6.0
+        ElseIf akLockpick > 50
             result += 3.0
+        ElseIf akLockpick > 25
+            result += 1.0
         Endif
         ; apply bonus for total successful escapes
-        Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue() as Int
-        If EscapesMade > 10
-            result += 1.0
-        Endif
-        If EscapesMade > 25
-            result += 1.0
-        Endif
-        If EscapesMade > 50
-            result += 1.0
-        Endif
+        Float EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue()
         If EscapesMade > 100
+            result += 4.0
+        ElseIf EscapesMade > 50
+            result += 3.0
+        ElseIf EscapesMade > 25
+            result += 2.0
+        ElseIf EscapesMade > 10
             result += 1.0
         Endif
     Endif
@@ -1420,28 +1414,27 @@ Float Function CalclulateStruggleSuccess()
     If BaseEscapeChance > 0.0
         ; add 1% for every previous attempt
         result += EscapeStruggleAttemptsMade        
+        Float akDestruction = Libs.PlayerRef.GetActorValue("Destruction")
+        Float akAlteration = Libs.PlayerRef.GetActorValue("Alteration")
         ; apply strength bonus
-        If Libs.PlayerRef.GetActorValue("Destruction") > 25 || Libs.PlayerRef.GetActorValue("Alteration") > 25
+        If akDestruction > 25 || akAlteration > 25
             result += 1.0
         Endif
-        If Libs.PlayerRef.GetActorValue("Destruction") > 50 || Libs.PlayerRef.GetActorValue("Alteration") > 50
+        If akDestruction > 50 || akAlteration > 50
             result += 2.0
         Endif
-        If Libs.PlayerRef.GetActorValue("Destruction") > 75 || Libs.PlayerRef.GetActorValue("Alteration") > 75
+        If akDestruction > 75 || akAlteration > 75
             result += 3.0
         Endif        
         ; apply bonus for total successful escapes
-        Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue() as Int
-        If EscapesMade > 10
-            result += 1.0
-        Endif
-        If EscapesMade > 25
-            result += 1.0
-        Endif
-        If EscapesMade > 50
-            result += 1.0
-        Endif
+        Float EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue()
         If EscapesMade > 100
+            result += 4.0
+        ElseIf EscapesMade > 50
+            result += 3.0
+        ElseIf EscapesMade > 25
+            result += 2.0
+        ElseIf EscapesMade > 10
             result += 1.0
         Endif
     Endif
@@ -1455,7 +1448,6 @@ EndFunction
 
 ; returns 0 when the escape attempt fails, 1 at success and -1 when no attempt was made due to cooldown
 Int Function RepairJammedLock(Float Chance)
-    Bool Success = False
     If Chance == 0.0
         ; no need to process, but returning here will prevent catastrophic failures when there is zero chance of success. We're not THAT mean!
         return 0

--- a/dist/scripts/source/zadEquipScript.psc
+++ b/dist/scripts/source/zadEquipScript.psc
@@ -869,7 +869,7 @@ Function DeviceMenuCarryOn()
 EndFunction
 
 Function DisplayDifficultyMsg()
-    Int StruggleEscapeChance = Math.Floor(BaseEscapeChance)
+    Int StruggleEscapeChance = BaseEscapeChance as Int
     String result = "You carefully examine the " + DeviceName + ". "
     If StruggleEscapeChance > 75
         result += "This restraint is fairly weak and will not offer much resistance against struggling."
@@ -1109,7 +1109,7 @@ Int Function Escape(Float Chance)
     If Utility.RandomFloat(0.0, 99.9) < (Chance * CalculateDifficultyModifier(True))
         libs.log("Player has escaped " + DeviceName)
         ; increase success counter
-        libs.zadDeviceEscapeSuccessCount.SetValueInt(libs.zadDeviceEscapeSuccessCount.GetValueInt() + 1)
+        libs.zadDeviceEscapeSuccessCount.SetValue(libs.zadDeviceEscapeSuccessCount.GetValue() + 1)
         RemoveDevice(libs.PlayerRef)
         libs.SendDeviceEscapeEvent(DeviceInventory, zad_DeviousDevice, true)
         return 1
@@ -1149,17 +1149,17 @@ Float Function CalclulateCutSuccess()
     If CutDeviceEscapeChance > 0.0
         ; add 1% for every previous attempt
         result += EscapeCutAttemptsMade        
-        If Libs.PlayerRef.GetAV("OneHanded") > 25
+        If Libs.PlayerRef.GetActorValue("OneHanded") > 25
             result += 1.0
         Endif
-        If Libs.PlayerRef.GetAV("OneHanded") > 50
+        If Libs.PlayerRef.GetActorValue("OneHanded") > 50
             result += 2.0
         Endif
-        If Libs.PlayerRef.GetAV("OneHanded") > 75
+        If Libs.PlayerRef.GetActorValue("OneHanded") > 75
             result += 3.0
         Endif
         ; apply bonus for total successful escapes
-        Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValueInt()
+        Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue() as Int
         If EscapesMade > 10
             result += 1.0
         Endif
@@ -1313,17 +1313,17 @@ Float Function CalclulateLockPickSuccess()
     If LockPickEscapeChance > 0.0
         ; add 1% for every previous attempt
         result += EscapeLockPickAttemptsMade        
-        If Libs.PlayerRef.GetAV("Lockpicking") > 25
+        If Libs.PlayerRef.GetActorValue("Lockpicking") > 25
             result += 1.0
         Endif
-        If Libs.PlayerRef.GetAV("Lockpicking") > 50
+        If Libs.PlayerRef.GetActorValue("Lockpicking") > 50
             result += 2.0
         Endif
-        If Libs.PlayerRef.GetAV("Lockpicking") > 75
+        If Libs.PlayerRef.GetActorValue("Lockpicking") > 75
             result += 3.0
         Endif
         ; apply bonus for total successful escapes
-        Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValueInt()
+        Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue() as Int
         If EscapesMade > 10
             result += 1.0
         Endif
@@ -1421,17 +1421,17 @@ Float Function CalclulateStruggleSuccess()
         ; add 1% for every previous attempt
         result += EscapeStruggleAttemptsMade        
         ; apply strength bonus
-        If Libs.PlayerRef.GetAV("Destruction") > 25 || Libs.PlayerRef.GetAV("Alteration") > 25
+        If Libs.PlayerRef.GetActorValue("Destruction") > 25 || Libs.PlayerRef.GetActorValue("Alteration") > 25
             result += 1.0
         Endif
-        If Libs.PlayerRef.GetAV("Destruction") > 50 || Libs.PlayerRef.GetAV("Alteration") > 50
+        If Libs.PlayerRef.GetActorValue("Destruction") > 50 || Libs.PlayerRef.GetActorValue("Alteration") > 50
             result += 2.0
         Endif
-        If Libs.PlayerRef.GetAV("Destruction") > 75 || Libs.PlayerRef.GetAV("Alteration") > 75
+        If Libs.PlayerRef.GetActorValue("Destruction") > 75 || Libs.PlayerRef.GetActorValue("Alteration") > 75
             result += 3.0
         Endif        
         ; apply bonus for total successful escapes
-        Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValueInt()
+        Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue() as Int
         If EscapesMade > 10
             result += 1.0
         Endif

--- a/dist/scripts/source/zadEquipScript.psc
+++ b/dist/scripts/source/zadEquipScript.psc
@@ -355,20 +355,20 @@ Event OnUnequipped(Actor akActor)
                     If !akActor.IsEquipped(deviceInventory)
                         akActor.EquipItem(deviceInventory, false, true)
                     EndIf                
-                    if !libs.PlayerRef.IsEquipped(deviceRendered)
+                    if !akActor.IsEquipped(deviceRendered)
                         akActor.EquipItem(deviceRendered, true, true)
                     EndIf
                     StorageUtil.UnsetIntValue(akActor, "zad_RemovalOperation" + zad_DeviousDevice)
                     return
                 EndIf
-                if !libs.PlayerRef.IsEquipped(deviceRendered) && akActor.GetItemCount(deviceInventory) < 2
+                if !akActor.IsEquipped(deviceRendered) && akActor.GetItemCount(deviceInventory) < 2
                     libs.Log("Caught remove-all (rendered device missing). Re-equipping device.")
                     akActor.EquipItem(deviceRendered, true, true)
                     StorageUtil.UnsetIntValue(akActor, "zad_RemovalOperation" + zad_DeviousDevice)
                     return
                 EndIf    
                 ; Player had to unequip item to access this. Reequip it immediately, to help avoid spam-unlocks.
-                libs.PlayerRef.EquipItem(deviceInventory, false, true)
+                akActor.EquipItem(deviceInventory, false, true)
                 DeviceMenu()
             Else
                 menuDisable = false
@@ -616,10 +616,8 @@ bool Function RemoveDeviceWithKey(actor akActor = none, bool destroyDevice=false
             EndIf
             Return False
         EndIf
-        If DestroyKey
+        If DestroyKey || (libs.Config.GlobalDestroyKey && DeviceKey.HasKeyword(libs.zad_NonUniqueKey))
             libs.PlayerRef.RemoveItem(DeviceKey, NumberOfKeysNeeded, False)
-        elseif libs.Config.GlobalDestroyKey && DeviceKey.HasKeyword(libs.zad_NonUniqueKey)
-            libs.PlayerRef.RemoveItem(DeviceKey, NumberOfKeysNeeded, False)    
         EndIf    
     EndIf        
     ; could call ProcessLinkedDeviceOnUnlock(Actor akActor)    here, but there is a theoretical chance that OnUnequipped() will not be completed before the new device will get locked on, so we're just signaling OnUnequipped() to do it.
@@ -943,15 +941,14 @@ Float Function CalculateDifficultyModifier(Bool operator = true)
     EndIf
     Float val = 1.0
     Int mcmValue = libs.config.EscapeDifficulty    
-    Int mcmLength = libs.config.EsccapeDifficultyList.Length
-    Int median = ((mcmLength - 1) / 2) As Int ; This assumes the array to be uneven, otherwise there is no median value.
+    Int median = ((libs.config.EsccapeDifficultyList.Length - 1) / 2) As Int ; This assumes the array to be uneven, otherwise there is no median value.
     Float maxModifier = 0.75 ; set this as desired - it's the maximum possible +/- modifier. It should not be larger than 1 (=100%)
     Float StepLength = maxModifier / median
     Int Steps = mcmValue - median    
     If operator
-        val = 1 + (Steps * StepLength)
+        val += (Steps * StepLength)
     Else
-        val = 1 - (Steps * StepLength)
+        val -= (Steps * StepLength)
     EndIf
     libs.log("Difficulty modifier applied: " + val + " [setting: " + mcmValue + "]")
     return val
@@ -968,15 +965,14 @@ Float Function CalculateCooldownModifier(Bool operator = true)
     EndIf
     Float val = 1.0
     Int mcmValue = libs.config.CooldownDifficulty    
-    Int mcmLength = libs.config.EsccapeDifficultyList.Length
-    Int median = ((mcmLength - 1) / 2) As Int ; This assumes the array to be uneven, otherwise there is no median value.
+    Int median = ((libs.config.EsccapeDifficultyList.Length - 1) / 2) As Int ; This assumes the array to be uneven, otherwise there is no median value.
     Float maxModifier = 0.9 ; set this as desired - it's the maximum possible +/- modifier. It should not be larger than 1 (=100%)
     Float StepLength = maxModifier / median
     Int Steps = mcmValue - median    
     If operator
-        val = 1 + (Steps * StepLength)
+        val += (Steps * StepLength)
     Else
-        val = 1 - (Steps * StepLength)
+        val -= (Steps * StepLength)
     EndIf
     libs.log("Difficulty modifier applied: " + val + " [setting: " + mcmValue + "]")
     return val
@@ -994,8 +990,7 @@ Float Function CalculateTimerModifier(float timerMin, float timerMax)
     Float timerRange = timerMax - timerMin
     ;use escape difficulty for calculations
     Int mcmValue = libs.config.EscapeDifficulty    
-    Int mcmLength = libs.config.EsccapeDifficultyList.Length
-    Float StepLength = timerRange / mcmLength
+    Float StepLength = timerRange / libs.config.EsccapeDifficultyList.Length
     ;let's call it escape chance instead - from zero to max
     float upperTargetBound = timerMax - mcmValue * StepLength
     float lowerTargetBound = timerMax - (mcmValue + 1) * StepLength
@@ -1014,8 +1009,7 @@ Float Function CalculateTimerModifier(float timerMin, float timerMax)
     ;sanity checks just because
     if val < timerMin
         val = timerMin
-    endIf
-    if val > timerMax
+    elseif val > timerMax
         val = timerMax
     endIf
     libs.log("Difficulty timer modifier applied: " + val + " [setting: " + mcmValue + "]")
@@ -1033,15 +1027,14 @@ Float Function CalculateKeyModifier(Bool operator = true)
     EndIf
     Float val = 1.0
     Int mcmValue = libs.config.KeyDifficulty    
-    Int mcmLength = libs.config.EsccapeDifficultyList.Length
-    Int median = ((mcmLength - 1) / 2) As Int ; This assumes the array to be uneven, otherwise there is no median value.
+    Int median = ((libs.config.EsccapeDifficultyList.Length - 1) / 2) As Int ; This assumes the array to be uneven, otherwise there is no median value.
     Float maxModifier = 1 ; set this as desired - it's the maximum possible +/- modifier. It should not be larger than 1 (=100%)
     Float StepLength = maxModifier / median
     Int Steps = mcmValue - median    
     If operator
-        val = 1 + (Steps * StepLength)
+        val += (Steps * StepLength)
     Else
-        val = 1 - (Steps * StepLength)
+        val -= (Steps * StepLength)
     EndIf
     libs.log("Difficulty modifier applied: " + val + " [setting: " + mcmValue + "]")
     return val

--- a/dist/scripts/source/zadEventBoots.psc
+++ b/dist/scripts/source/zadEventBoots.psc
@@ -1,11 +1,10 @@
 scriptName zadEventBoots extends zadBaseEvent
 
 bool Function HasKeywords(actor akActor)
-	Bool isWearingSafeShoes = akActor.WornHasKeyword( Keyword.GetKeyword( "zad_effect_noTripping" ) )
 	if !libs.AllowGenericEvents(akActor, libs.zad_DeviousBoots)
 		return false
 	else
-		return (akActor.WornHasKeyword(libs.zad_DeviousBoots) && !isWearingSafeShoes)
+		return (akActor.WornHasKeyword(libs.zad_DeviousBoots) && !akActor.WornHasKeyword( Keyword.GetKeyword( "zad_effect_noTripping" ) ))
 	endif
 EndFunction
 

--- a/dist/scripts/source/zadEventCatsuit.psc
+++ b/dist/scripts/source/zadEventCatsuit.psc
@@ -7,16 +7,9 @@ bool Function HasKeywords(actor akActor)
 	elseif !akActor.WornHasKeyword(libs.zad_DeviousSuit)
 		return false
 	else
-		string s = ""
-		armor a = libs.GetWornDevice(akActor, libs.zad_DeviousSuit)
-		if a
-			; no keyword specifically for catsuits.
-			s = a.GetName()
-			if StringUtil.Find(s, "cat") != -1
-				return true
-			endif
-		endif		
-		return false
+		armor a = zadNativeFunctions.GetWornDevice(akActor, libs.zad_DeviousSuit)
+		; no keyword specifically for catsuits.
+		return a != None && StringUtil.Find(a.GetName(), "cat") != -1
 	endif
 EndFunction
 

--- a/dist/scripts/source/zadEventCatsuit.psc
+++ b/dist/scripts/source/zadEventCatsuit.psc
@@ -14,7 +14,7 @@ bool Function HasKeywords(actor akActor)
 EndFunction
 
 Function Execute(actor akActor)
-	if libs.PlayerRef.IsInInterior() == 1
+	if !libs.PlayerRef.IsInInterior()
 		PlayerIsOutside()
 	else
 		PlayerIsInside()
@@ -29,7 +29,9 @@ Function PlayerIsOutside()
 	
 	;let's use vampire sun damage to determine if it really is a factor
 	;the time of day is silly for it however, let's determine that 9-15 the sun is high enough
-	if weathertype == 0 && currenthour >= 9 && currenthour <= 15 && currentsundamage == 1
+	if weathertype == -1
+		PlayerIsInside()
+	elseif weathertype == 0 && currenthour >= 9 && currenthour <= 15 && currentsundamage == 1
 		libs.NotifyPlayer("The sun on your suit makes you sweat even more.")
 	elseif weathertype == 0 && currenthour >= 9 && currenthour <= 15 && currentsundamage < 1
 		libs.NotifyPlayer("The warmth of the day makes you sweat more.")
@@ -45,8 +47,6 @@ Function PlayerIsOutside()
 		libs.NotifyPlayer("The snow melts agains your suit, you feel chilly.")
 	elseif weathertype == 3 && currenthour < 9 && currenthour > 15
 		libs.NotifyPlayer("The suit feels exceedingly cold.")
-	else
-		PlayerIsInside()
 	endif
 
 EndFunction

--- a/dist/scripts/source/zadEventCatsuit.psc
+++ b/dist/scripts/source/zadEventCatsuit.psc
@@ -75,7 +75,7 @@ EndFunction
 
 float Function GetCurrentTimeOfDay()
 	float Time = libs.GameDaysPassed.GetValue()
-	Time -= Math.Floor(Time) ; Remove "previous in-game days passed" bit
+	Time -= Time as Int ; Remove "previous in-game days passed" bit
 	Time *= 24 ; Convert from fraction of a day to number of hours
 	Return Time
 EndFunction

--- a/dist/scripts/source/zadEventPeriodicShocker.psc
+++ b/dist/scripts/source/zadEventPeriodicShocker.psc
@@ -6,8 +6,6 @@ EndFunction
 
 Function Execute(actor akActor)
 	if akActor == libs.playerRef
-		bool hasPlugs = false
-		bool hasPiercings = false
 		armor vPlug = StorageUtil.GetFormValue(akActor, "zad_Equipped" + libs.LookupDeviceType(libs.zad_DeviousPlugVaginal) + "_Rendered") as Armor
 		armor vPiercing = StorageUtil.GetFormValue(akActor, "zad_Equipped" + libs.LookupDeviceType(libs.zad_DeviousPiercingsVaginal) + "_Rendered") as Armor
 		if vPiercing && (vPiercing.HasKeyword(libs.zad_EffectShocking))

--- a/dist/scripts/source/zadEventPostureCollar.psc
+++ b/dist/scripts/source/zadEventPostureCollar.psc
@@ -6,17 +6,9 @@ bool Function HasKeywords(actor akActor)
 	elseif !akActor.WornHasKeyword(libs.zad_DeviousCollar)
 		return false
 	else
-		string s = ""
-		armor a = libs.GetWornDevice(akActor, libs.zad_DeviousCollar)
-		if a
-			; no keyword specifically for posture collars.
-			s = a.GetName()
-			if StringUtil.Find(s, "Posture") != -1
-				return true
-			endif
-		endif		
-		return false
-		;return (akActor.WornHasKeyword(libs.zad_DeviousCollar) && akActor.IsEquipped(libs.collarPosture) )
+		armor a = zadNativeFunctions.GetWornDevice(akActor, libs.zad_DeviousCollar)
+		; no keyword specifically for posture collars.
+		return a != None && StringUtil.Find(a.GetName(), "Posture") != -1
 	endif
 EndFunction
 

--- a/dist/scripts/source/zadGagNoFoodEffect.psc
+++ b/dist/scripts/source/zadGagNoFoodEffect.psc
@@ -3,8 +3,6 @@ ScriptName zadGagNoFoodEffect extends ActiveMagicEffect
 ; Libraries
 zadLibs Property Libs Auto
 
-actor Property Target Auto
-
 ObjectReference Property Refrigerator Auto
 Keyword Property FoodKeyword Auto
 Keyword Property RawFoodKeyword Auto

--- a/dist/scripts/source/zadLibs.psc
+++ b/dist/scripts/source/zadLibs.psc
@@ -671,7 +671,7 @@ EndFunction
 ; determines if a device in a given slot is generic (e.g. no quest device). Caution: Works for equipped devices only.
 Bool Function IsGenericDevice(Actor a, Keyword kw)
 	Armor arm = GetWornRenderedDeviceByKeyword(a, kw)	
-	if arm && arm.HasKeyword(zad_BlockGeneric) || arm.HasKeyword(zad_QuestItem)
+	if arm && (arm.HasKeyword(zad_BlockGeneric) || arm.HasKeyword(zad_QuestItem))
 		return false
 	EndIf
 	return true

--- a/dist/scripts/source/zadLibs.psc
+++ b/dist/scripts/source/zadLibs.psc
@@ -283,15 +283,8 @@ Keyword Property questItemRemovalAuthorizationToken = None Auto
 FormList Property zadDeviceTypes Auto	; List of all main device type keywords. Useful for iterating functions.
 FormList Property zad_AlwaysSilent Auto	; Actors in this list will ALWAYS equip or unequip DD items silently.
 
-GlobalVariable _GameDaysPassed
-GlobalVariable Property GameDaysPassed
-    GlobalVariable Function Get()
-        if !_GameDaysPassed
-            _GameDaysPassed = Game.GetForm(0x00000039) as GlobalVariable
-        endif
-        return _GameDaysPassed
-    EndFunction
-EndProperty
+GlobalVariable Property GameDaysPassed Auto
+Bool Property HasPPlus Auto Hidden
 
 ; Rechargeable Soulgem Stuff
 Soulgem Property SoulgemEmpty Auto
@@ -509,10 +502,7 @@ EndFunction
 Bool Function UnlockDeviceByKeyword(actor akActor, keyword zad_DeviousDevice, bool destroyDevice = false)
 	Log("UnlockDeviceByKeyword called for " + zad_DeviousDevice)					
 	Armor idevice = GetWornDevice(akActor, zad_DeviousDevice)
-	if UnlockDevice(akActor, idevice, zad_DeviousDevice = zad_DeviousDevice, destroyDevice = destroyDevice, genericonly = true)
-		return true
-	EndIf
-	return false
+	return UnlockDevice(akActor, idevice, zad_DeviousDevice = zad_DeviousDevice, destroyDevice = destroyDevice, genericonly = true)
 EndFunction
 
 ; Remove quest device from actor. To make sure the removal is legit this will work only if the keyword passed to the function in the RemovalToken parameter is present on the item. Standard DD and ZAP keywords will not be accepted. 
@@ -837,8 +827,9 @@ Function InflateAnalPlug(actor akActor, int amount = 1)
 		; nothing to do
 		return
 	EndIf	
+	Bool isPlayer = akActor == playerref
 	int currentVal = -1
-	If akActor == PlayerRef
+	If isPlayer
 		currentVal = zadInflatablePlugStateAnal.GetValue() as Int
 		; only increase the value up to 5, but make it count as an inflation event even if it's maximum inflated
 		if currentVal < 5			
@@ -860,7 +851,7 @@ Function InflateAnalPlug(actor akActor, int amount = 1)
 		return
 	EndIf	
 	; don't play the animation in combat if it's the player
-	if akActor == playerref && playerref.IsInCombat() 
+	if isPlayer && playerref.IsInCombat() 
 		return 
 	Endif	
 	If aroused.GetActorExposure(akActor) < 90 || zadInflatablePlugStateAnal.GetValue() < 3
@@ -879,8 +870,9 @@ Function InflateVaginalPlug(actor akActor, int amount = 1)
 		; nothing to do
 		return
 	EndIf
+	Bool isPlayer = akActor == playerref
 	int currentVal = -1
-	If akActor == PlayerRef
+	If isPlayer
 		currentVal = zadInflatablePlugStateVaginal.GetValue() as Int
 		; only increase the value up to 5, but make it count as an inflation event even if it's maximum inflated
 		if currentVal < 5						
@@ -902,7 +894,7 @@ Function InflateVaginalPlug(actor akActor, int amount = 1)
 		return
 	EndIf	
 	; don't play the animation in combat if it's the player
-	if akActor == playerref && playerref.IsInCombat() 
+	if isPlayer && playerref.IsInCombat() 
 		return 
 	Endif	
 	If aroused.GetActorExposure(akActor) < 90 || zadInflatablePlugStateVaginal.GetValue() < 3
@@ -917,8 +909,10 @@ Function InflateVaginalPlug(actor akActor, int amount = 1)
 EndFunction
 
 Function InflateRandomPlug(actor akActor, int amount = 1)
+	Bool inflateV = akActor.WornHasKeyword(zad_kw_InflatablePlugVaginal)
+	Bool inflateA = akActor.WornHasKeyword(zad_kw_InflatablePlugAnal)
 	; pick one randomly if both are worn:
-	If akActor.WornHasKeyword(zad_kw_InflatablePlugVaginal) && akActor.WornHasKeyword(zad_kw_InflatablePlugAnal)
+	If inflateV && inflateA
 		If Utility.RandomInt(1,2) == 1
 			InflateVaginalPlug(akActor, amount)
 		Else
@@ -926,11 +920,11 @@ Function InflateRandomPlug(actor akActor, int amount = 1)
 		EndIf
 		return
 	EndIf
-	If akActor.WornHasKeyword(zad_kw_InflatablePlugVaginal)
+	If inflateV
 		InflateVaginalPlug(akActor, amount)
 		return
 	EndIf
-	If akActor.WornHasKeyword(zad_kw_InflatablePlugAnal)
+	If inflateA
 		InflateAnalPlug(akActor, amount)
 		return
 	EndIf
@@ -986,11 +980,14 @@ EndFunction
 ; Function to test an NPC using certain criteria,
 bool Function ValidForInteraction(actor currenttest, int genderreq = -1, bool creatureok = false, bool animalok = false, bool beastreaceok = false, bool elderok = false, bool guardok = true)
 	log("Checking actor validity for interaction")
-	If currenttest.HasKeyword(ActorTypeNPC)		
+	Bool isNPC = currenttest.HasKeyword(ActorTypeNPC)
+	Bool isCreature = currenttest.HasKeyword(ActorTypeCreature)
+	Bool isAnimal = currenttest.HasKeyword(ActorTypeAnimal)
+	If isNPC
 		log("Processing: " + currenttest.GetLeveledActorBase().GetName() + ". Is NPC.")		
-	elseIf currenttest.HasKeyword(ActorTypeCreature) && !currenttest.HasKeyword(ActorTypeAnimal)
+	elseIf isCreature && !isAnimal
 		log("Processing: " + currenttest.GetLeveledActorBase().GetName() + ". Is Creature.")		
-	elseIf currenttest.HasKeyword(ActorTypeAnimal)		
+	elseIf isAnimal
 		log("Processing: " + currenttest.GetLeveledActorBase().GetName() + ". Is Animal.")		
 	else		
 		log("Processing: " + currenttest.GetLeveledActorBase().GetName() + ". WARNING: Type cannot be determined. Rejected!")
@@ -1004,25 +1001,27 @@ bool Function ValidForInteraction(actor currenttest, int genderreq = -1, bool cr
 		log("Rejected: " + currenttest.GetLeveledActorBase().GetName() + ". Reason: Actor is player character, follower, disabled, child, dwarven construct, a prisoner, or dead.")		
 		return false
 	endif		
-	; if it's an NPC, make sure it's correct gender
-	If genderreq > 0
-		If currenttest.HasKeyword(ActorTypeNPC) && (currenttest.GetLeveledActorBase().GetSex() != genderreq)
-			log("Rejected: " + currenttest.GetLeveledActorBase().GetName() + ". Reason: Actor is wrong gender.")				
-			return false			
-		EndIf
-	EndIf
 	; make sure it is not guard, an elder or beast race if they are disallowed
-	if currenttest.HasKeyword(ActorTypeNPC) && ((!elderok && currenttest.GetLeveledActorBase().GetRace() == ElderRace) || (!beastreaceok && currenttest.HasKeyword(isBeastRace)) || (!guardok && currenttest.IsInFaction(isGuardFaction)))		
-		log("Rejected: " + currenttest.GetLeveledActorBase().GetName() + ". Reason: Actor is disallowed guard/elder/beast race (MCM settings).")		
-		return false			
-	endif		
+	if isNPC
+		; if it's an NPC, make sure it's correct gender
+		If genderreq > 0
+			If (currenttest.GetLeveledActorBase().GetSex() != genderreq)
+				log("Rejected: " + currenttest.GetLeveledActorBase().GetName() + ". Reason: Actor is wrong gender.")				
+				return false			
+			EndIf
+		EndIf
+		If ((!elderok && currenttest.GetLeveledActorBase().GetRace() == ElderRace) || (!beastreaceok && currenttest.HasKeyword(isBeastRace)) || (!guardok && currenttest.IsInFaction(isGuardFaction)))		
+			log("Rejected: " + currenttest.GetLeveledActorBase().GetName() + ". Reason: Actor is disallowed guard/elder/beast race (MCM settings).")		
+			return false			
+		endif
+	EndIf
 	; if it's a creature, make sure they are allowed
-	if currenttest.HasKeyword(ActorTypeCreature) && !creatureok					
+	if !creatureok && isCreature
 		log("Rejected: " + currenttest.GetLeveledActorBase().GetName() + ". Reason: Actor is humanoid creature.")			
 		Return false		
 	endif	
 	; if it's a animal, make sure they are allowed
-	if currenttest.HasKeyword(ActorTypeAnimal) && !animalok
+	if !animalok && isAnimal
 		log("Rejected: " + currenttest.GetLeveledActorBase().GetName() + ". Reason: Actor is animal.")	
 		Return false		
 	endif	
@@ -1075,10 +1074,7 @@ EndFunction
 
 Bool Function HasBreastsExposed(Actor a)
 	Form arm = a.GetWornForm(0x00000004)
-	if !arm || a.WornHasKeyword(zad_ExposedBreasts)
-		return true
-	endif
-	return false
+	return !arm || a.WornHasKeyword(zad_ExposedBreasts)
 EndFunction
 
 ;====================
@@ -1330,10 +1326,7 @@ bool Function WearingConflictingDevice(actor akActor, armor deviceRendered, keyw
 	if akActor == none
 		Error("WearingConflictingDevice received none argument.")
 	EndIf
-	if akActor.GetItemCount(deviceRendered)==0 && akActor.WornHasKeyword(zad_DeviousDevice)
-		return true
-	Endif
-	return false
+	return akActor.GetItemCount(deviceRendered)==0 && akActor.WornHasKeyword(zad_DeviousDevice)
 EndFunction
 
 
@@ -1363,7 +1356,7 @@ Function UpdateExposure(actor akRef, float val, bool skipMultiplier=false)
 		
 	Else
 		float rate = Aroused.GetActorExposureRate(akRef)
-		int newRank = (lastRank + (val as float) * rate) as int	
+		int newRank = (lastRank + val * rate) as int	
 		Aroused.SetActorExposure(akRef, newRank)
 	EndIf
 EndFunction
@@ -1389,18 +1382,12 @@ EndFunction
 
 
 Function SendDeviceRemovalEvent(string deviceName, actor akActor)
-	int isPlayer = 0
-	if akActor == PlayerRef
-		isPlayer = 1
-	EndIf
+	int isPlayer = (akActor == PlayerRef) as Int
 	SendDeviceEvent("DeviceRemoved"+deviceName, akActor.GetLeveledActorBase().GetName(), isPlayer)
 EndFunction
 
 Function SendDeviceEquippedEvent(string deviceName, actor akActor)
-	int isPlayer = 0
-	if akActor == PlayerRef
-		isPlayer = 1
-	EndIf
+	int isPlayer = (akActor == PlayerRef) as Int
 	SendDeviceEvent("DeviceEquipped"+deviceName, akActor.GetLeveledActorBase().GetName(), isPlayer)
 EndFunction
 
@@ -1502,48 +1489,46 @@ Function DDI_DebugFixDevices()
 	bool clearAll = True
 	While i > 0			
 		i -= 1
-		kForm = PlayerRef.GetNthForm(i)	
-		If (kForm As Armor)
-			if kForm.HasKeyword(zad_InventoryDevice) && PlayerRef.IsEquipped(kForm)
-				idevice = kForm As Armor
-				if idevice
-					ObjectReference tmpORef = PlayerRef.placeAtMe(kForm, abInitiallyDisabled = true)
-					zadEquipScript tmpZRef = tmpORef as zadEquipScript
-					if tmpZRef != none && PlayerRef.GetItemCount(tmpZRef.deviceRendered) > 0
-						rdevice = tmpZRef.deviceRendered as Armor
-						zadTemporaryDeviceStorage.AddForm(rdevice)
-						clearAll = False
-					Endif
-					tmpORef.delete()
+		idevice = PlayerRef.GetNthForm(i) As Armor
+		If idevice
+			if idevice.HasKeyword(zad_InventoryDevice) && PlayerRef.IsEquipped(idevice)
+				ObjectReference tmpORef = PlayerRef.placeAtMe(idevice, abInitiallyDisabled = true)
+				zadEquipScript tmpZRef = tmpORef as zadEquipScript
+				if tmpZRef != none && PlayerRef.GetItemCount(tmpZRef.deviceRendered) > 0
+					rdevice = tmpZRef.deviceRendered as Armor
+					zadTemporaryDeviceStorage.AddForm(rdevice)
+					clearAll = False
 				Endif
+				tmpORef.delete()
 			Endif
 		Endif
 	EndWhile
 	i = PlayerRef.GetNumItems()
 	While i > 0			
 		i -= 1
-		kForm = PlayerRef.GetNthForm(i)
-		if (kForm As Armor)
-			if kForm.HasKeyword(zad_Lockable) && !kForm.HasKeyword(zad_InventoryDevice)
-				Int c = PlayerRef.GetItemCount(kForm)
+		idevice = PlayerRef.GetNthForm(i) as Armor
+		if idevice
+			if idevice.HasKeyword(zad_Lockable) && !idevice.HasKeyword(zad_InventoryDevice)
+				Int c = PlayerRef.GetItemCount(idevice)
 				if clearAll
-					PlayerRef.RemoveItem(kForm,c,true)
+					PlayerRef.RemoveItem(idevice,c,true)
 				else
 					Int j = zadTemporaryDeviceStorage.GetSize()
 					bool removeRendered = True
 					while j > 0
 						j -= 1
 						rdevice = zadTemporaryDeviceStorage.GetAt(j) as Armor
-						if rdevice == kForm
+						if rdevice == idevice
 							removeRendered = False
+							j = 0
 						EndIf
 					EndWhile
 					if removeRendered
-						PlayerRef.RemoveItem(kForm,c,true)
+						PlayerRef.RemoveItem(idevice,c,true)
 						RemovedItems += c
 					elseif c > 1
-						c = c - 1
-						PlayerRef.RemoveItem(kForm,c,true)
+						c -= 1
+						PlayerRef.RemoveItem(idevice,c,true)
 						RemovedItems += c
 					Endif
 				Endif
@@ -1561,49 +1546,42 @@ Function DDI_DebugTerminate()
 	log("DDI_DebugTerminate called. Removing devices.")
 	Notify("DDI Debug Terminate signal triggered.\nAttempting to clear all DD items, including quest devices.", MessageBox = True)	
 	Utility.Wait(1)
-	Armor idevice = None
-	Armor rdevice = None
-	Keyword kw = None
-	Keyword token = None
 	if !PlayerRef.WornHasKeyword(zad_Lockable)
 		; no DD items equipped, can abort here
 		Notify("No DD items found on the player. Aborting.", MessageBox = True)	
 		return
 	endif			
+	Armor idevice = None
+	Armor rdevice = None
+	Keyword kw = None
+	Keyword token = None
 	Int i = PlayerRef.GetNumItems()
 	While i > 0			
 		i -= 1
-		Form kForm = PlayerRef.GetNthForm(i)	
-		If (kForm As Armor)
-			if kForm.HasKeyword(zad_InventoryDevice)
-				idevice = kForm As Armor
-				if idevice
-					rdevice = GetRenderedDevice(idevice)
-					kw = GetDeviceKeyword(idevice)
-					If idevice && rdevice && kw
-						; we got a valid DD item here, let's remove it
-						If idevice.HasKeyword(zad_QuestItem) || rdevice.HasKeyword(zad_QuestItem)
-							; It's a quest item, so we need a token to pass the checks. This is the only way I am aware of to remove 3rd party quest items. And again, I don't want to see content mods doing that.
-							Int k = rdevice.GetNumKeywords()
-							Bool done = false
-							Keyword dKeyword
-							While k > 0 && !done
-								k -= 1
-								dKeyword = rdevice.GetNthKeyword(k)
-								if dKeyword && !zadStandardKeywords.HasForm(dKeyword)
-									token = dKeyword
-									done = true
-								EndIf	
-							EndWhile
-							if token
-								RemoveQuestDevice(PlayerRef, idevice, rdevice, kw, token, destroyDevice = true, skipMutex = true)
-							EndIf
-						Else
-							removeDevice(PlayerRef, idevice, rdevice, kw, destroyDevice = true, skipevents = false, skipmutex = true)			
-						EndIf
-						Utility.Wait(1)
+		idevice = PlayerRef.GetNthForm(i) As Armor
+		If idevice && idevice.HasKeyword(zad_InventoryDevice)
+			rdevice = GetRenderedDevice(idevice)
+			kw = GetDeviceKeyword(idevice)
+			If rdevice && kw
+				; we got a valid DD item here, let's remove it
+				If idevice.HasKeyword(zad_QuestItem) || rdevice.HasKeyword(zad_QuestItem)
+					; It's a quest item, so we need a token to pass the checks. This is the only way I am aware of to remove 3rd party quest items. And again, I don't want to see content mods doing that.
+					Int k = rdevice.GetNumKeywords()
+					Keyword dKeyword
+					While k > 0 && !token
+						k -= 1
+						dKeyword = rdevice.GetNthKeyword(k)
+						if dKeyword && !zadStandardKeywords.HasForm(dKeyword)
+							token = dKeyword
+						EndIf	
+					EndWhile
+					if token
+						RemoveQuestDevice(PlayerRef, idevice, rdevice, kw, token, destroyDevice = true, skipMutex = true)
 					EndIf
-				Endif			
+				Else
+					removeDevice(PlayerRef, idevice, rdevice, kw, destroyDevice = true, skipevents = false, skipmutex = true)			
+				EndIf
+				Utility.Wait(1)
 			EndIf
 		EndIf
 	EndWhile
@@ -1619,15 +1597,17 @@ EndFunction
 
 function Masturbate(actor a, bool feedback = false)	
 	sslBaseAnimation[] Manims 
-	If a == PlayerRef && feedback
-		NotifyPlayer("You cannot resist your urges anymore!")
-	Else
-		If a.GetLeveledActorBase().GetSex() == 1 && feedback
-			NotifyPlayer(a.GetLeveledActorBase().GetName() + " can't resist her urges anymore...")
-		ElseIf a.GetLeveledActorBase().GetSex() == 0 && feedback
-			NotifyPlayer(a.GetLeveledActorBase().GetName() + " can't resist his urges anymore...")
-		Endif
-	EndIf	
+	If feedback
+		If a == PlayerRef
+			NotifyPlayer("You cannot resist your urges anymore!")
+		Else
+			If a.GetLeveledActorBase().GetSex() == 1
+				NotifyPlayer(a.GetLeveledActorBase().GetName() + " can't resist her urges anymore...")
+			Else
+				NotifyPlayer(a.GetLeveledActorBase().GetName() + " can't resist his urges anymore...")
+			Endif
+		EndIf
+	EndIf
 	If a.WornHasKeyword(zad_DeviousArmbinder)
 		Manims = New sslBaseAnimation[1]
 		Manims[0] = SexLab.GetAnimationObject("DDArmbinderSolo")
@@ -2041,7 +2021,8 @@ int Function VibrateEffectV2(actor akActor, int vibStrength, int duration, bool 
 	Log("VibrateEffect("+vibStrength +" for "+duration+" sec). VibrateMult: "+numVibratorsMult)
 	
 	bool actorIsPlayer = (akActor == PlayerRef)
-	if !silent && actorIsPlayer
+	Bool verbose = !silent && actorIsPlayer
+	if verbose
 		string msg = BuildVibrationString(akActor, vibStrength, vPlug, aPlug, vPiercings, nPiercings)
 		NotifyPlayer(msg)
 	Endif
@@ -2105,7 +2086,7 @@ int Function VibrateEffectV2(actor akActor, int vibStrength, int duration, bool 
 							msID = -1
 						endIf
 						StopVibrating(akActor)
-						if !silent && actorIsPlayer
+						if verbose
 							NotifyPlayer("The vibrations abruptly stop just short of bringing you to orgasm.")
 						Endif
 						EdgeActor(akActor)
@@ -2114,7 +2095,7 @@ int Function VibrateEffectV2(actor akActor, int vibStrength, int duration, bool 
 					Else
 						; Orgasm. Continue VibrateEffect.
 						actorCame += 1
-						if !silent && actorIsPlayer
+						if verbose
 							string o_msg = BuildVibrationOrgasmString(akActor, vibStrength, vPlug, aPlug, vPiercings, nPiercings)
 							NotifyPlayer(o_msg)
 						EndIf
@@ -2191,7 +2172,7 @@ int Function VibrateEffectV2(actor akActor, int vibStrength, int duration, bool 
 		vibAnimStarted = 0
 	EndIf
 	StopVibrating(akActor)
-	if !silent && actorIsPlayer
+	if verbose
 		NotifyPlayer(BuildPostVibrationString(akActor, vibStrength, vPlug, aPlug, vPiercings, nPiercings))
 	Endif
 	SendModEvent("DeviceVibrateEffectStop", akActor.GetLeveledActorBase().GetName(), vibStrength * numVibratorsMult)
@@ -2234,7 +2215,7 @@ Sound Function GetVibrateSound(int vibStrength)
 EndFunction
 
 Function AttrDrain(actor akActor, string attr)
-	float randomize = (Utility.RandomInt(1,75) as Float) / 100
+	float randomize = Utility.RandomInt(1,75) / 100
 	int drain = (akActor.GetActorValue(attr) * randomize) as Int
 	Log(attr+"DrainEffect(): Draining "+drain + "("+randomize+" %)")
 	akActor.DamageActorValue(attr, drain)
@@ -2257,12 +2238,7 @@ EndFunction
 
 
 Bool Function ShouldEdgeActor(actor akActor)
-	if ActorHasKeyword(akActor, zad_EffectEdgeOnly)
-		return true
-	ElseIf ActorHasKeyword(akActor, zad_EffectEdgeRandom) && Utility.RandomInt() >= 25
-		return true
-	EndIf
-	return false
+	return ActorHasKeyword(akActor, zad_EffectEdgeOnly) || (ActorHasKeyword(akActor, zad_EffectEdgeRandom) && Utility.RandomInt() >= 25)
 EndFunction
 
 Bool Function ActorHasKeyword(actor akActor, keyword kwd)
@@ -2281,9 +2257,10 @@ Function SpellCastVibrate(Actor akActor, Form tmp)
 		SendModEvent("EventOnCast")
 		Log("OnSpellCast()")
 		If akActor == PlayerRef && akActor.GetCombatState() >= 1
+			Float currentRealTime = Utility.GetCurrentRealTime()
 			; punish her only every so often
-			if (Utility.GetCurrentRealTime() > SpellCastVibrateCooldown)					
-				SpellCastVibrateCooldown = Utility.GetCurrentRealTime() + 60 ; 60 seconds cooldown
+			if (currentRealTime > SpellCastVibrateCooldown)					
+				SpellCastVibrateCooldown = currentRealTime + 60 ; 60 seconds cooldown
 			else
 				return
 			endif		
@@ -2391,10 +2368,7 @@ EndFunction
 ;==================================================
 ; Is the actor animating through Sexlab, or DD?
 bool Function IsAnimating(actor akActor)
-	if (akActor.GetSitState() != 0) || akActor.IsOnMount()
-		return True
-	endif
-	return (akActor.IsInFaction(zadAnimatingFaction) || akActor.IsInFaction(Sexlab.AnimatingFaction))
+	return (akActor.GetSitState() != 0) || akActor.IsOnMount() || (akActor.IsInFaction(zadAnimatingFaction) || akActor.IsInFaction(Sexlab.AnimatingFaction))
 EndFunction
 
 ; Set DD's actor animating status.
@@ -2491,7 +2465,8 @@ Function RepopulateNpcs()
 		Log("RepopulateNpcs(): In menu mode, aborting.")
 		return
 	EndIf
-	if Utility.GetCurrentRealTime() - lastRepopulateTime < 10
+	Float currentRealTime = Utility.GetCurrentRealTime()
+	if currentRealTime - lastRepopulateTime < 10
 		Log("RepopulateNpcs(): Skipping due to recent cell change.")
 		return
 	EndIf
@@ -2502,12 +2477,12 @@ Function RepopulateNpcs()
 	EndIf
 	repopulateMutex=true
 	Log("RepopulateNpcs()")
-	if Utility.GetCurrentRealTime() - lastRepopulateTime <= 5
+	if currentRealTime - lastRepopulateTime <= 5
 		Log("Aborting repopulation of NPC slots: Hit throttle.")
 		repopulateMutex=false
 		return
 	EndIf
-	lastRepopulateTime = Utility.GetCurrentRealTime()
+	lastRepopulateTime = currentRealTime
 	if zadNPCQuest.IsProcessing
 		Log("Waiting, since NPC Events is currently processing.")
 		int timeout = 0
@@ -2708,20 +2683,25 @@ EndFunction
 ; putting stuff there no longer does anything, it's kept for backwards-compatibility but should be removed eventually
 Function ApplyBoundAnim(actor akActor, idle theIdle = None)
 	Log("ApplyBoundAnim()")
-	if akActor.GetEquippedWeapon()
-		akActor.UnequipItem(akActor.GetEquippedWeapon(), false, true)
+	Weapon eWeapon = akActor.GetEquippedWeapon()
+	if eWeapon
+		akActor.UnequipItem(eWeapon, false, true)
 	EndIf
-	if akActor.GetEquippedWeapon(True)
-		akActor.UnequipItem(akActor.GetEquippedWeapon(true), false, true)
+	eWeapon = akActor.GetEquippedWeapon(True)
+	if eWeapon
+		akActor.UnequipItem(eWeapon, false, true)
 	EndIf
-	If akActor.GetEquippedShield()
-		akActor.UnequipItem(akActor.GetEquippedShield(), false, true)
+	Armor eArmor = akActor.GetEquippedShield()
+	If eArmor
+		akActor.UnequipItem(eArmor, false, true)
 	EndIf
-	if akActor.GetEquippedSpell(0)
-		akActor.UnequipSpell(akActor.GetEquippedSpell(0), 0)
+	Spell eSpell = akActor.GetEquippedSpell(0)
+	if eSpell
+		akActor.UnequipSpell(eSpell, 0)
 	EndIf
-	if akActor.GetEquippedSpell(1)
-		akActor.UnequipSpell(akActor.GetEquippedSpell(1), 1)
+	eSpell = akActor.GetEquippedSpell(1)
+	if eSpell
+		akActor.UnequipSpell(eSpell, 1)
 	EndIf
 	if akActor.IsWeaponDrawn()
 		if config.UseBoundCombat
@@ -2729,9 +2709,7 @@ Function ApplyBoundAnim(actor akActor, idle theIdle = None)
 		EndIf
 		akActor.SheatheWeapon()
 	EndIf
-	if akActor.IsOnMount()
-		akActor.Dismount()
-	EndIf
+	akActor.Dismount()
 EndFunction
 
 ; Turns off dialogue processing. Note that Pausing uses a reference counting

--- a/dist/scripts/source/zadLibs.psc
+++ b/dist/scripts/source/zadLibs.psc
@@ -384,7 +384,7 @@ Bool Property PlayerIsInCancellableAnimation = false Auto Hidden ; Flag used to 
 Bool Function LockDevice(actor akActor, armor deviceInventory, bool force = false)
 	Log("LockDevice called for " + akActor.GetLeveledActorBase().GetName() + ": "+ deviceInventory.GetName() + ")")
 	If force
-		Keyword kw = GetDeviceKeyword(deviceInventory)
+		Keyword kw = zadNativeFunctions.GetPropertyForm(deviceInventory,"zad_DeviousDevice") as Keyword
 		if kw
 			return SwapDevices(akActor, deviceInventory, zad_DeviousDevice = kw)						
 		EndIf
@@ -418,38 +418,32 @@ Bool Function UnlockDevice(actor akActor, armor deviceInventory, armor deviceRen
 		; Same when more than one copy of a device worn is in the inventory, even for the player. 
 		; Well, the later has been considered a "known issue" for as long as DD existed, so there is that... :S
 		; Stupid Skyrim derp engine! Even force-equipping a device before calling UnEquipItem() fails 20-30% of the time, so we have to do this the hard way.		
-		Armor rDevice
-		Keyword kw		
 		if !zad_DeviousDevice
-			kw = GetDeviceKeyword(deviceInventory)
+			zad_DeviousDevice = zadNativeFunctions.GetPropertyForm(deviceInventory,"zad_DeviousDevice") as Keyword
 			; this is a slow operation - For NPC's, TRY to provide the function with the keyword if you at all can!
-		else
-			kw = zad_DeviousDevice
 		EndIf
 		if !deviceRendered
-			rdevice = GetWornRenderedDeviceByKeyword(akActor, kw)			
-		else
-			rdevice = deviceRendered
+			deviceRendered = GetWornRenderedDeviceByKeyword(akActor, zad_DeviousDevice)			
 		EndIf		
-		akActor.RemoveItem(rdevice, 1, true)
+		akActor.RemoveItem(deviceRendered, 1, true)
 		; duplicate all the crap that normally would be handled by OnUnequipped() or OnRemoveDevice(), because it won't be called in this case. Gah!!!!!!!!
-		 If (kw == zad_DeviousHeavyBondage || kw == zad_DeviousPonyGear || kw == zad_DeviousHobbleSkirt)
+		 If (zad_DeviousDevice == zad_DeviousHeavyBondage || zad_DeviousDevice == zad_DeviousPonyGear || zad_DeviousDevice == zad_DeviousHobbleSkirt)
 			log("Removing Bound Effects")
 			BoundCombat.EvaluateAA(akActor)
 		EndIf		
-		If kw == zad_DeviousGag
+		If zad_DeviousDevice == zad_DeviousGag
 			log("Removing Gag Effects")
 			RemoveGagEffect(akActor)
-			if rDevice.HasKeyWord(zad_DeviousGagPanel)
+			if deviceRendered.HasKeyWord(zad_DeviousGagPanel)
 				if akActor.GetFactionRank(zadGagPanelFaction) == 0
 					akActor.RemoveItem(zad_GagPanelPlug, 1)
 				EndIf
 				akActor.RemoveFromFaction(zadGagPanelFaction)
 			EndIf
 		EndIf
-		UnsetStoredDevice(akActor, kw)		
+		UnsetStoredDevice(akActor, zad_DeviousDevice)		
 		SendDeviceRemovalEvent(LookupDeviceType(zad_DeviousDevice), akActor)
-		SendDeviceRemovedEventVerbose(deviceInventory, kw, akActor)		
+		SendDeviceRemovedEventVerbose(deviceInventory, zad_DeviousDevice, akActor)		
 		Log("UnlockDevice: " + akActor.GetLeveledActorBase().GetName() + "'s " + deviceInventory.GetName() + " has been removed.")
 	EndIf    
 	if destroyDevice
@@ -463,16 +457,13 @@ EndFunction
 ; This function will behave like LockDevice() if no conflicting device is equipped, but it WILL be slower, if no keyword is provided.
 Bool Function SwapDevices(actor akActor, armor deviceInventory, keyword zad_DeviousDevice = none, bool destroyDevice = false, bool genericonly = true)
 	Log("SwapDevices called for " + akActor.GetLeveledActorBase().GetName() + ": "+ deviceInventory.GetName() + ")")
-	Keyword kw		
 	if !zad_DeviousDevice
-		kw = GetDeviceKeyword(deviceInventory)		
-	else
-		kw = zad_DeviousDevice
+		zad_DeviousDevice = zadNativeFunctions.GetPropertyForm(deviceInventory,"zad_DeviousDevice") as Keyword
 	EndIf	
-	Armor WornDevice = GetWornRenderedDeviceByKeyword(akActor, kw)
+	Armor WornDevice = GetWornRenderedDeviceByKeyword(akActor, zad_DeviousDevice)
 	if WornDevice
-		Armor idevice = GetWornDevice(akActor, kw)		
-		if !UnlockDevice(akActor, idevice, WornDevice, zad_DeviousDevice = kw, destroyDevice = destroyDevice, genericonly = genericonly)
+		Armor idevice = zadNativeFunctions.GetWornDevice(akActor, zad_DeviousDevice)		
+		if !UnlockDevice(akActor, idevice, WornDevice, zad_DeviousDevice = zad_DeviousDevice, destroyDevice = destroyDevice, genericonly = genericonly)
 			log("UnlockDevice() failed. Aborting.")
 			return false
 		EndIf		
@@ -501,7 +492,7 @@ EndFunction
 ; Removes a device in a given slot by providing a keyword.
 Bool Function UnlockDeviceByKeyword(actor akActor, keyword zad_DeviousDevice, bool destroyDevice = false)
 	Log("UnlockDeviceByKeyword called for " + zad_DeviousDevice)					
-	Armor idevice = GetWornDevice(akActor, zad_DeviousDevice)
+	Armor idevice = zadNativeFunctions.GetWornDevice(akActor, zad_DeviousDevice)
 	return UnlockDevice(akActor, idevice, zad_DeviousDevice = zad_DeviousDevice, destroyDevice = destroyDevice, genericonly = true)
 EndFunction
 
@@ -1560,8 +1551,8 @@ Function DDI_DebugTerminate()
 		i -= 1
 		idevice = PlayerRef.GetNthForm(i) As Armor
 		If idevice && idevice.HasKeyword(zad_InventoryDevice)
-			rdevice = GetRenderedDevice(idevice)
-			kw = GetDeviceKeyword(idevice)
+			rdevice = zadNativeFunctions.GetRenderDevice(idevice) as Armor
+			kw = zadNativeFunctions.GetPropertyForm(idevice,"zad_DeviousDevice") as Keyword
 			If rdevice && kw
 				; we got a valid DD item here, let's remove it
 				If idevice.HasKeyword(zad_QuestItem) || rdevice.HasKeyword(zad_QuestItem)
@@ -2886,13 +2877,8 @@ string Function LookupDeviceType(keyword kwd)
 EndFunction
 
 function strip(actor a, bool animate = false)
-    Spell spl
-    Weapon weap
-    Armor sh
-    Ammo amm
-    Form frm
     stripweapons(a)
-    frm = a.GetWornForm(0x00001000) ; circlet
+    Form frm = a.GetWornForm(0x00001000) ; circlet
     if frm && !frm.HasKeyWordString("SexLabNoStrip")
         a.unequipItem(frm, abSilent = true)
     endif
@@ -3074,7 +3060,7 @@ EndFunction
 ; Deprecated: Use either LockDevice() or UnlockDevice() with genericonly = true
 bool Function ManipulateGenericDevice(actor akActor, armor device, bool equipOrUnequip, bool skipEvents = false , bool skipMutex = false)
 	bool manipulated = false
-	Keyword kw = GetDeviceKeyword(device)
+	Keyword kw = zadNativeFunctions.GetPropertyForm(device,"zad_DeviousDevice") as Keyword
     Armor loc_rd = GetRenderDevice(device)
 	if loc_rd.HasKeyword(zad_BlockGeneric) || loc_rd.HasKeyword(zad_QuestItem)
 		Warn("ManipulateGenericDevice called on non-generic device.")
@@ -3348,7 +3334,7 @@ Function RegisterGenericDevice(Armor inventoryDevice, String tags)
 		return
 	endIf
 	
-	Keyword kw = GetDeviceKeyword(inventoryDevice)
+	Keyword kw = zadNativeFunctions.GetPropertyForm(inventoryDevice,"zad_DeviousDevice") as Keyword
 	if kw == none
 		return
 	endIf
@@ -3397,20 +3383,24 @@ Armor Function GetDeviceByTags(Keyword kw, String tags, bool requireAll = true, 
 	While i > 0
 		i -= 1
 		Armor current = StorageUtil.FormListGet(kw, "zad.GenericDevice", i) as Armor
-		If current && HasTags(current, tagArray, requireAll) && !HasTags(current, supArray, false)
-			resultList[n]	= current
-			n += 1
-		ElseIf current == none
+		If current
+			If HasTags(current, tagArray, requireAll) && !HasTags(current, supArray, false)
+				resultList[n]	= current
+				n += 1
+			EndIf
+		Else
 			StorageUtil.FormListRemoveAt(kw, "zad.GenericDevice", i)
 		EndIf
 	EndWhile
 	
-	if n < 1 && fallBack
-		log("No devices found with tags, falling back to random device")
-		return GetGenericDeviceByKeyword(kw)
-	ElseIf n < 1
-		log("No devices found with tags")
-		return none
+	if n < 1
+		If fallBack
+			log("No devices found with tags, falling back to random device")
+			return GetGenericDeviceByKeyword(kw)
+		Else
+			log("No devices found with tags")
+			return none
+		endIf
 	endIf
 	return resultList[Utility.RandomInt(0, n - 1)] as Armor
 EndFunction

--- a/dist/scripts/source/zadLibs.psc
+++ b/dist/scripts/source/zadLibs.psc
@@ -31,7 +31,7 @@ zadBoundCombatScript Property BoundCombat auto
 Int Property TweenMenuKey Auto
 bool Property Terminate Auto
 zadexpressionlibs Property ExpLibs auto ;expression libs
-Quest Property vrikActionsAPI = None Auto
+Quest Property vrikActionsAPI = None Auto Hidden
   
 ; Keywords
 Keyword Property zad_DeviousPlug Auto
@@ -267,7 +267,7 @@ Bool Property DeviceMutex Auto ; Prevent oddities when swapping sets of items qu
 Bool Property GlobalEventFlag Auto ; Events enabled/disabled, globally. Useful for scenes that don't want to be interrupted.
 bool Property RepopulateMutex Auto ; Avoid 2.6.3 bug
 Float Property lastRepopulateTime Auto ; Avoid 2.6.3 bug
-bool Property EnableVRSupport = False Auto
+bool Property EnableVRSupport = False Auto Hidden
   
 ; Misc
 Actor Property PlayerRef Auto
@@ -277,9 +277,9 @@ Faction Property zadNGEdgedFaction Auto ; Faction to store actors getting edged
 Spell Property ShockEffect Auto
 Float Property SpellCastVibrateCooldown Auto
 Spell Property zad_splMagickaPenalty Auto
-bool Property BoundAnimsAvailable = True Auto ; Obsolete. Bound anims are now always available, post zap 6
+bool Property BoundAnimsAvailable = True Auto Hidden; Obsolete. Bound anims are now always available, post zap 6
 FormList Property zadStandardKeywords Auto
-Keyword Property questItemRemovalAuthorizationToken = None Auto
+Keyword Property questItemRemovalAuthorizationToken = None Auto Hidden
 FormList Property zadDeviceTypes Auto	; List of all main device type keywords. Useful for iterating functions.
 FormList Property zad_AlwaysSilent Auto	; Actors in this list will ALWAYS equip or unequip DD items silently.
 
@@ -297,8 +297,8 @@ Keyword Property zad_kw_InflatablePlugAnal Auto
 Keyword Property zad_kw_InflatablePlugVaginal Auto
 GlobalVariable Property zadInflatablePlugStateAnal Auto
 GlobalVariable Property zadInflatablePlugStateVaginal Auto
-Float Property LastInflationAdjustmentVaginal = 0.0 Auto
-Float Property LastInflationAdjustmentAnal = 0.0 Auto
+Float Property LastInflationAdjustmentVaginal = 0.0 Auto Hidden
+Float Property LastInflationAdjustmentAnal = 0.0 Auto Hidden
 Message Property zad_PlugsConfirmMSG Auto
 Message Property zad_PlugsDeflatePumpsFail Auto
 

--- a/dist/scripts/source/zadLibs.psc
+++ b/dist/scripts/source/zadLibs.psc
@@ -840,7 +840,7 @@ Function InflateAnalPlug(actor akActor, int amount = 1)
 	EndIf	
 	int currentVal = -1
 	If akActor == PlayerRef
-		currentVal = zadInflatablePlugStateAnal.GetValueInt()
+		currentVal = zadInflatablePlugStateAnal.GetValue() as Int
 		; only increase the value up to 5, but make it count as an inflation event even if it's maximum inflated
 		if currentVal < 5			
 			currentVal += amount
@@ -848,7 +848,7 @@ Function InflateAnalPlug(actor akActor, int amount = 1)
 				currentVal = 5
 			EndIf
 			log("Setting anal plug inflation to " + (currentVal))
-			zadInflatablePlugStateAnal.SetValueInt(currentVal)
+			zadInflatablePlugStateAnal.SetValue(currentVal)
 		EndIf	
 		LastInflationAdjustmentAnal = GameDaysPassed.GetValue()
 	EndIf
@@ -864,7 +864,7 @@ Function InflateAnalPlug(actor akActor, int amount = 1)
 	if akActor == playerref && playerref.IsInCombat() 
 		return 
 	Endif	
-	If aroused.GetActorExposure(akActor) < 90 || zadInflatablePlugStateAnal.GetValueInt() < 3
+	If aroused.GetActorExposure(akActor) < 90 || zadInflatablePlugStateAnal.GetValue() < 3
 		notify("Your plug makes you more horny...")
 		SexlabMoan(akActor)	
 		PlayHornyAnimation(akActor)	
@@ -882,7 +882,7 @@ Function InflateVaginalPlug(actor akActor, int amount = 1)
 	EndIf
 	int currentVal = -1
 	If akActor == PlayerRef
-		currentVal = zadInflatablePlugStateVaginal.GetValueInt()
+		currentVal = zadInflatablePlugStateVaginal.GetValue() as Int
 		; only increase the value up to 5, but make it count as an inflation event even if it's maximum inflated
 		if currentVal < 5						
 			currentVal += amount
@@ -890,7 +890,7 @@ Function InflateVaginalPlug(actor akActor, int amount = 1)
 				currentVal = 5
 			EndIf
 			log("Setting vaginal plug inflation to " + (currentVal))
-			zadInflatablePlugStateVaginal.SetValueInt(currentVal)
+			zadInflatablePlugStateVaginal.SetValue(currentVal)
 		EndIf	
 		LastInflationAdjustmentVaginal = GameDaysPassed.GetValue()
 	EndIf
@@ -906,7 +906,7 @@ Function InflateVaginalPlug(actor akActor, int amount = 1)
 	if akActor == playerref && playerref.IsInCombat() 
 		return 
 	Endif	
-	If aroused.GetActorExposure(akActor) < 90 || zadInflatablePlugStateVaginal.GetValueInt() < 3
+	If aroused.GetActorExposure(akActor) < 90 || zadInflatablePlugStateVaginal.GetValue() < 3
 		notify("Your plug makes you more horny...")
 		SexlabMoan(akActor)	
 		PlayHornyAnimation(akActor)	
@@ -944,14 +944,14 @@ Function DeflateVaginalPlug(actor akActor, int amount = 1)
 	EndIf	
 	int currentVal = -1
 	If akActor == PlayerRef
-		currentVal = zadInflatablePlugStateVaginal.GetValueInt()		
+		currentVal = zadInflatablePlugStateVaginal.GetValue() as Int
 		if currentVal > 0
 			currentVal -= amount
 			if currentVal < 0
 				currentVal = 0
 			EndIf
 			log("Setting vaginal plug inflation to " + (currentVal))
-			zadInflatablePlugStateVaginal.SetValueInt(currentVal)
+			zadInflatablePlugStateVaginal.SetValue(currentVal)
 		EndIf	
 		LastInflationAdjustmentVaginal = GameDaysPassed.GetValue()	
 	EndIf
@@ -965,14 +965,14 @@ Function DeflateAnalPlug(actor akActor, int amount = 1)
 	EndIf	
 	int currentVal = -1
 	If akActor == PlayerRef
-		currentVal = zadInflatablePlugStateAnal.GetValueInt()		
+		currentVal = zadInflatablePlugStateAnal.GetValue() as Int
 		if currentVal > 0
 			currentVal -= amount
 			if currentVal < 0
 				currentVal = 0
 			EndIf
 			log("Setting anal plug inflation to " + (currentVal))
-			zadInflatablePlugStateAnal.SetValueInt(currentVal)
+			zadInflatablePlugStateAnal.SetValue(currentVal)
 		EndIf	
 		LastInflationAdjustmentAnal = GameDaysPassed.GetValue()	
 	EndIf
@@ -2236,9 +2236,9 @@ EndFunction
 
 Function AttrDrain(actor akActor, string attr)
 	float randomize = (Utility.RandomInt(1,75) as Float) / 100
-	int drain = (akActor.GetAv(attr) * randomize) as Int
+	int drain = (akActor.GetActorValue(attr) * randomize) as Int
 	Log(attr+"DrainEffect(): Draining "+drain + "("+randomize+" %)")
-	akActor.DamageAv(attr, drain)
+	akActor.DamageActorValue(attr, drain)
 EndFunction
 
 
@@ -2760,8 +2760,8 @@ EndFunction
 ; prevent dialogue from becoming stuck.
 ; 
 Function ResetDialogue()
-	DialogueGagDisable.SetValueInt(0)
-	DialogueArmbinderDisable.SetValueInt(0)
+	DialogueGagDisable.SetValue(0)
+	DialogueArmbinderDisable.SetValue(0)
 EndFunction
 
 ; Adds the actor to the faction that disables the built in gag

--- a/dist/scripts/source/zadLibs.psc
+++ b/dist/scripts/source/zadLibs.psc
@@ -263,10 +263,9 @@ Message Property zad_DD_OnPutOnDevice Auto					; Message to be displayed when th
 
 ; Internal Variables
 Armor Property deviceRemovalToken Auto         ; Internal token for removal events
-Bool Property DeviceMutex Auto ; Prevent oddities when swapping sets of items quickly.
-Bool Property GlobalEventFlag Auto ; Events enabled/disabled, globally. Useful for scenes that don't want to be interrupted.
-bool Property RepopulateMutex Auto ; Avoid 2.6.3 bug
-Float Property lastRepopulateTime Auto ; Avoid 2.6.3 bug
+Bool Property DeviceMutex Auto Hidden; Prevent oddities when swapping sets of items quickly.
+Bool Property GlobalEventFlag Auto Hidden; Events enabled/disabled, globally. Useful for scenes that don't want to be interrupted.
+Float Property lastRepopulateTime Auto Hidden; Avoid 2.6.3 bug
 bool Property EnableVRSupport = False Auto Hidden
   
 ; Misc
@@ -759,7 +758,7 @@ EndFunction
 ; Retrieves rendered device for a given inventory device
 ; Useful to check for keywords only present on the rendered device
 Armor Function GetRenderedDevice(armor device)
-    return zadNativeFunctions.GetRenderDevice(device) as Armor
+    return zadNativeFunctions.GetRenderDevice(device)
 EndFunction
 
 ; for the sake of cleaner coding
@@ -1551,7 +1550,7 @@ Function DDI_DebugTerminate()
 		i -= 1
 		idevice = PlayerRef.GetNthForm(i) As Armor
 		If idevice && idevice.HasKeyword(zad_InventoryDevice)
-			rdevice = zadNativeFunctions.GetRenderDevice(idevice) as Armor
+			rdevice = zadNativeFunctions.GetRenderDevice(idevice)
 			kw = zadNativeFunctions.GetPropertyForm(idevice,"zad_DeviousDevice") as Keyword
 			If rdevice && kw
 				; we got a valid DD item here, let's remove it
@@ -1628,9 +1627,9 @@ function Masturbate(actor a, bool feedback = false)
 		return
 	Else
 		If a.GetLeveledActorBase().GetSex() == 1
-			Manims = SexLab.GetAnimationsByTag(1, "Solo", "F", requireAll=true)
+			Manims = SexLab.GetAnimationsByTags(1, "Solo,F", requireAll=true)
 		Else
-			Manims = SexLab.GetAnimationsByTag(1, "Solo", "M", requireAll=true)
+			Manims = SexLab.GetAnimationsByTags(1, "Solo,M", requireAll=true)
 		Endif
 	Endif
 	actor[] tmp = new actor[1]
@@ -1763,9 +1762,7 @@ bool Function PlaySceneAndWait(Scene toPlay, bool forceStart=false, int timeout=
 		Utility.Wait(increment)
 	EndWhile
 	if i >= timeout
-		if toPlay.IsPlaying()
-			toPlay.Stop()
-		EndIf
+		toPlay.Stop()
 		Log("Scene timed out.")
 		return false
 	EndIf
@@ -2019,12 +2016,12 @@ int Function VibrateEffectV2(actor akActor, int vibStrength, int duration, bool 
 	Endif
 
 	; Initialize vibe sounds
-	float vibSoundVol = Config.VolumeVibrator
-	if !actorIsPlayer
-		vibSoundVol = Config.VolumeVibratorNPC
-	EndIf
 	int vsID = GetVibrateSound(vibStrength).Play(akActor)
-	Sound.SetInstanceVolume(vsID, vibSoundVol)
+	if !actorIsPlayer
+		Sound.SetInstanceVolume(vsID, Config.VolumeVibratorNPC)
+	Else
+		Sound.SetInstanceVolume(vsID, Config.VolumeVibrator)
+	EndIf
 
 	; Start base expression
 	int currentArousal = Aroused.GetActorExposure(akActor)
@@ -2243,7 +2240,6 @@ Function ApplyMagickaPenalty(actor akActor)
 EndFunction
 	
 Function SpellCastVibrate(Actor akActor, Form tmp)
-	Spell theSpell = (tmp as Spell)
 	if Utility.RandomInt() < config.EffectVibrateChance && akActor.WornHasKeyword(zad_DeviousPlug) && ActorHasKeyword(akActor, zad_EffectVibrateOnSpellCast)
 		SendModEvent("EventOnCast")
 		Log("OnSpellCast()")
@@ -2262,7 +2258,7 @@ Function SpellCastVibrate(Actor akActor, Form tmp)
 		Endif
 		Shout isShout = (tmp as Shout)
 		; Log("isShout: "+isShout)
-		int cost = theSpell.GetEffectiveMagickaCost(akActor)
+		int cost = (tmp as Spell).GetEffectiveMagickaCost(akActor)
 		if cost <= 1 && !isShout
 			return
 		EndIf
@@ -2446,33 +2442,35 @@ String Function AnimSwitchKeyword( actor akActor, string idleName )
 	Error("Failed to find valid animation for presentation.")
 EndFunction
 
+State BUSY
+	Function RepopulateNpcs()
+		Log("RepopulateNpcs() is already processing.")
+	EndFunction
+EndState
+
 Function RepopulateNpcs()
+	GoToState("BUSY"); Avoid this getting hit too quickly while comparing times.
 	; ---- SAFETY GUARD ----
 	if !PlayerRef || !PlayerRef.Is3DLoaded()
 		Log("RepopulateNpcs(): Player not fully loaded, aborting.")
+		GoToState("")
 		return
 	EndIf
 	if Utility.IsInMenuMode()
 		Log("RepopulateNpcs(): In menu mode, aborting.")
+		GoToState("")
 		return
 	EndIf
 	Float currentRealTime = Utility.GetCurrentRealTime()
 	if currentRealTime - lastRepopulateTime < 10
 		Log("RepopulateNpcs(): Skipping due to recent cell change.")
+		GoToState("")
 		return
 	EndIf
 	; ---- Safety Guard against potential VM Lockups on cell change ----
-	if repopulateMutex ; Avoid this getting hit too quickly while comparing times.
-		Log("RepopulateNpcs() is already processing.")
-		return
-	EndIf
-	repopulateMutex=true
+
 	Log("RepopulateNpcs()")
-	if currentRealTime - lastRepopulateTime <= 5
-		Log("Aborting repopulation of NPC slots: Hit throttle.")
-		repopulateMutex=false
-		return
-	EndIf
+
 	lastRepopulateTime = currentRealTime
 	if zadNPCQuest.IsProcessing
 		Log("Waiting, since NPC Events is currently processing.")
@@ -2487,13 +2485,11 @@ Function RepopulateNpcs()
 		EndIf
 	EndIf
 	if !zadNPCSlots.IsStopping() && !zadNPCSlots.IsStarting()
-		if zadNPCSlots.IsRunning()
-			zadNPCSlots.Stop()
-		EndIf
+		zadNPCSlots.Stop()
 		If config.NumNpcs>0
 			; Feels like a race condition / timing issue?
 			; Perhaps if I call a short wait (Thus suspending execution, giving the quest a chance to fully stop?), it won't occur.
-			Utility.Wait(2.0)
+			Utility.Wait(0.1)
 			zadNPCSlots.Start()
 		Else
 			Log("Not repopulating NPC slots: Feature is disabled.")
@@ -2501,7 +2497,7 @@ Function RepopulateNpcs()
 	Else
 		Warn("Not repopulating NPC slots: Quest is changing state.")
 	EndIf
-	repopulateMutex=false
+	GoToState("")
 EndFunction
 
 Function PlugPanelGag(actor akActor)
@@ -2944,9 +2940,7 @@ Event StartBoundEffects(Actor akTarget)
 	Log("OnEffectStart(): Bound Effects")
 	PlayBoundIdle()
 	RegisterForSingleUpdate(8.0)
-	if aktarget == PlayerRef
-		UpdateControls()
-	Endif
+	UpdateControls()
 EndEvent
 
 Event StopBoundEffects(Actor akTarget)

--- a/dist/scripts/source/zadLibs.psc
+++ b/dist/scripts/source/zadLibs.psc
@@ -1472,7 +1472,6 @@ Function DDI_DebugFixDevices()
 	log("DDI_DebugFixDevices called. Attempting to fix broken devices.")
 	Armor idevice = None
 	Armor rdevice = None
-	Form kForm = None
 	Int RemovedItems = 0
 	zadTemporaryDeviceStorage.Revert()
 	Int i = PlayerRef.GetNumItems()

--- a/dist/scripts/source/zadLibs.psc
+++ b/dist/scripts/source/zadLibs.psc
@@ -451,7 +451,6 @@ Bool Function UnlockDevice(actor akActor, armor deviceInventory, armor deviceRen
 				if akActor.GetFactionRank(zadGagPanelFaction) == 0
 					akActor.RemoveItem(zad_GagPanelPlug, 1)
 				EndIf
-				akActor.SetFactionRank(zadGagPanelFaction, 0)
 				akActor.RemoveFromFaction(zadGagPanelFaction)
 			EndIf
 		EndIf
@@ -2401,7 +2400,6 @@ EndFunction
 ; Set DD's actor animating status.
 Function SetAnimating(actor akActor, bool isAnimating=true)
 	if isAnimating
-		akActor.AddToFaction(zadAnimatingFaction)
 		akActor.SetFactionRank(zadAnimatingFaction, 1)
 	Else
 		akActor.RemoveFromFaction(zadAnimatingFaction)
@@ -2431,7 +2429,6 @@ EndFunction
 
 ; Stop vibration event on actor.
 Function StopVibrating(actor akActor)
-	akActor.SetFactionRank(zadVibratorFaction, 0)
 	akActor.RemoveFromFaction(zadVibratorFaction)
 EndFunction
 

--- a/dist/scripts/source/zadMufflingStateScript.psc
+++ b/dist/scripts/source/zadMufflingStateScript.psc
@@ -76,9 +76,7 @@ EndEvent
 
 Event OnMenuClose(string MenuName)
 	; Update stored user volume settings when they close the main menu, since they may have changed them.
-	If MenuName == "Journal Menu"
-		StoreUserVolumes()
-	EndIf
+	StoreUserVolumes()
 EndEvent
 
 Function StoreUserVolumes()

--- a/dist/scripts/source/zadNPCQuestScript.psc
+++ b/dist/scripts/source/zadNPCQuestScript.psc
@@ -5,8 +5,8 @@ Scriptname ZadNPCQuestScript Extends  zadBaseDeviceQuest
 ReferenceAlias[] Property MonitoredNPCs Auto
 zadBQ00 Property questScript Auto
 
-Float Property LastUpdateTime Auto
-Bool Property IsProcessing Auto
+Float Property LastUpdateTime Auto Hidden
+Bool Property IsProcessing Auto Hidden
 
 Function DoRegisterGameTime()
     if GetName() == "zadNPCSlots"

--- a/dist/scripts/source/zadNPCQuestScript.psc
+++ b/dist/scripts/source/zadNPCQuestScript.psc
@@ -50,22 +50,20 @@ Event OnUpdateGameTime()
             actor akActor
             int i = 0
             while i < libs.Config.NumNpcs
-                if MonitoredNpcs[i]
-                    akActor = MonitoredNpcs[i].GetReference() as Actor
-                    if akActor && libs.IsValidActor(akActor)
-                        ; questScript.ProcessEffects(akActor)
-                        if akActor.WornHasKeyword(libs.zad_DeviousBelt)
-                            ; When I get around to adding more of these, I'll stagger it in the same way I did in zadbq00
-                            zadBaseEvent horny = libs.EventSlots.GetByName("Horny")
-                            if horny && horny.Filter(akActor)
-                                horny.Eval(akActor)
-                            EndIf
-                        Endif
-                        if akActor.WornHasKeyword(libs.zad_DeviousPlug)
-                            zadBaseEvent vibrate = libs.EventSlots.GetByName("Vibration")
-                            if vibrate && vibrate.Filter(akActor)
-                                vibrate.Eval(akActor)
-                            EndIf
+                akActor = MonitoredNpcs[i].GetReference() as Actor
+                if akActor && libs.IsValidActor(akActor)
+                    ; questScript.ProcessEffects(akActor)
+                    if akActor.WornHasKeyword(libs.zad_DeviousBelt)
+                        ; When I get around to adding more of these, I'll stagger it in the same way I did in zadbq00
+                        zadBaseEvent horny = libs.EventSlots.GetByName("Horny")
+                        if horny && horny.Filter(akActor)
+                            horny.Eval(akActor)
+                        EndIf
+                    Endif
+                    if akActor.WornHasKeyword(libs.zad_DeviousPlug)
+                        zadBaseEvent vibrate = libs.EventSlots.GetByName("Vibration")
+                        if vibrate && vibrate.Filter(akActor)
+                            vibrate.Eval(akActor)
                         EndIf
                     EndIf
                 EndIf
@@ -82,11 +80,9 @@ Event OnUpdate()
     int i = 0
     actor akActor
     while i < libs.Config.NumNpcs
-        if MonitoredNpcs[i]
-            akActor = MonitoredNpcs[i].GetReference() as Actor
-            if akActor && libs.IsValidActor(akActor)
-                ProcessArmbinderEffect(akActor)
-            EndIf
+        akActor = MonitoredNpcs[i].GetReference() as Actor
+        if akActor && libs.IsValidActor(akActor)
+            ProcessArmbinderEffect(akActor)
         EndIf
         i += 1
     EndWhile

--- a/dist/scripts/source/zadNPCQuestScript.psc
+++ b/dist/scripts/source/zadNPCQuestScript.psc
@@ -51,7 +51,7 @@ Event OnUpdateGameTime()
             int i = 0
             while i < libs.Config.NumNpcs
                 if MonitoredNpcs[i]
-                    akActor = MonitoredNpcs[i].GetActorReference()
+                    akActor = MonitoredNpcs[i].GetReference() as Actor
                     if akActor && libs.IsValidActor(akActor)
                         ; questScript.ProcessEffects(akActor)
                         if akActor.WornHasKeyword(libs.zad_DeviousBelt)
@@ -83,7 +83,7 @@ Event OnUpdate()
     actor akActor
     while i < libs.Config.NumNpcs
         if MonitoredNpcs[i]
-            akActor = MonitoredNpcs[i].GetActorReference()
+            akActor = MonitoredNpcs[i].GetReference() as Actor
             if akActor && libs.IsValidActor(akActor)
                 ProcessArmbinderEffect(akActor)
             EndIf

--- a/dist/scripts/source/zadPlayerScript.psc
+++ b/dist/scripts/source/zadPlayerScript.psc
@@ -32,7 +32,7 @@ Event OnAnimationStart(string eventName, string argString, float argNum, form se
     int actor_count = SceneActors.length
     while i < actor_count
         if SceneActors[i].WornHasKeyword(libs.zad_DeviousGag)
-			If HasPPlus
+			If libs.HasPPlus
 				If SceneActors[i].GetActorBase().GetSex() == 1 ;p+ fix
 					controller.SetVoice(SceneActors[i], libs.SexLab.GetVoiceByTags("Female,Gagged", "", True))
 					libs.SexLab.OpenMouth(SceneActors[i])

--- a/dist/scripts/source/zadPlayerScript.psc
+++ b/dist/scripts/source/zadPlayerScript.psc
@@ -28,9 +28,9 @@ Event OnAnimationStart(string eventName, string argString, float argNum, form se
     libs.log("SL scene started: Checking for gagged voices")
     sslThreadController controller = libs.SexLab.HookController(argString)
     actor[] SceneActors = libs.SexLab.HookActors(argString)
-    int i = 0
-    int actor_count = SceneActors.length
-    while i < actor_count
+    int i = SceneActors.length
+    while i > 0
+		i -= 1
         if SceneActors[i].WornHasKeyword(libs.zad_DeviousGag)
 			If libs.HasPPlus
 				If SceneActors[i].GetActorBase().GetSex() == 1 ;p+ fix
@@ -47,7 +47,6 @@ Event OnAnimationStart(string eventName, string argString, float argNum, form se
         else
             libs.log(SceneActors[i].GetLeveledActorBase().GetName() + " is not gagged.")
         endif
-        i += 1
     endwhile
 EndEvent
 
@@ -79,18 +78,21 @@ Function RegisterKeys()
 EndFunction
 
 Event OnKeyDown(int keyCode)
+    If Utility.IsInMenuMode()
+        Return
+    EndIf
     ; Animation cancel
-    if keyCode == Input.GetMappedKey("Jump", 0) || keyCode == Input.GetMappedKey("Jump", 2)
-        If libs.PlayerIsInCancellableAnimation
+    If libs.PlayerIsInCancellableAnimation
+        if keyCode == Input.GetMappedKey("Jump", 0) || keyCode == Input.GetMappedKey("Jump", 2)
             ; the correct pre-anim camera state is usually local to the function starting the animation, so it's hard to get.
             ; I'll just use this for now. It won't properly restore first person, but that's really a big deal.
             bool[] camState = new bool[2]
             libs.EndThirdPersonAnimation(libs.PlayerRef, camState)
             libs.PlayerIsInCancellableAnimation = false
+        Else
+            ; This can only happen if a registered key was remapped. If so, we should re-register.
+            RegisterKeys()
         EndIf
-    Else
-        ; This can only happen if a registered key was remapped. If so, we should re-register.
-        RegisterKeys()
     EndIf
 EndEvent
 
@@ -111,7 +113,6 @@ EndEvent
 
 Event OnPlayerLoadGame()
     AddInventoryEventFilter(libs.SoulgemFilled)
-    RegisterForMenu("MapMenu")
     actor akActor = libs.PlayerRef
     libs.HasPPlus = SKSE.GetPluginVersion("SexLabUtil") >= 34340864
     libs.SpellCastVibrateCooldown = 0.0
@@ -127,7 +128,9 @@ Event OnPlayerLoadGame()
         libs.MuteOverEncumberedMSG()
     endif
     Game.UpdateHairColor()
+    RegisterForMenu("MapMenu")
     RegisterEvents()
+    RegisterKeys()
     InitGagSpeak(false)
 EndEvent
 

--- a/dist/scripts/source/zadPlayerScript.psc
+++ b/dist/scripts/source/zadPlayerScript.psc
@@ -32,12 +32,14 @@ Event OnAnimationStart(string eventName, string argString, float argNum, form se
     int actor_count = SceneActors.length
     while i < actor_count
         if SceneActors[i].WornHasKeyword(libs.zad_DeviousGag)
-			If SKSE.GetPluginVersion("SexLabUtil") >= 34340864 && SceneActors[i].GetActorBase().GetSex() == 1 ;p+ fix
-				controller.SetVoice(SceneActors[i], libs.SexLab.GetVoiceByTags("Female,Gagged", "", True))
-				libs.SexLab.OpenMouth(SceneActors[i])
-			ElseIf SKSE.GetPluginVersion("SexLabUtil") >= 34340864 && SceneActors[i].GetActorBase().GetSex() == 0 ;p+ fix
-				controller.SetVoice(SceneActors[i], libs.SexLab.GetVoiceByTags("Male,Gagged", "", True))
-				libs.SexLab.OpenMouth(SceneActors[i])
+			If HasPPlus
+				If SceneActors[i].GetActorBase().GetSex() == 1 ;p+ fix
+					controller.SetVoice(SceneActors[i], libs.SexLab.GetVoiceByTags("Female,Gagged", "", True))
+					libs.SexLab.OpenMouth(SceneActors[i])
+				Else
+					controller.SetVoice(SceneActors[i], libs.SexLab.GetVoiceByTags("Male,Gagged", "", True))
+					libs.SexLab.OpenMouth(SceneActors[i])
+				EndIf
 			else ;regular SL way of switching voices
 				controller.SetVoice(SceneActors[i], libs.SexLab.GetVoiceBySlot(voiceslots[SceneActors[i].GetActorBase().GetSex()]))
 			endif
@@ -99,6 +101,8 @@ endEvent
 bool _initiated = false
 Event OnUpdate()
     if !_initiated
+        libs.HasPPlus = SKSE.GetPluginVersion("SexLabUtil") >= 34340864
+        AddInventoryEventFilter(libs.SoulgemFilled)
         RegisterEvents()
         InitGagSpeak(true)
         _initiated = true
@@ -106,14 +110,16 @@ Event OnUpdate()
 EndEvent
 
 Event OnPlayerLoadGame()
+    AddInventoryEventFilter(libs.SoulgemFilled)
+    RegisterForMenu("MapMenu")
     actor akActor = libs.PlayerRef
+    libs.HasPPlus = SKSE.GetPluginVersion("SexLabUtil") >= 34340864
     libs.SpellCastVibrateCooldown = 0.0
     libs.ExpLibs.Maintenance()
     CheckForSoftDepends()
     questScript.Maintenance()
     cameraState.Maintenance()
     libs.ResetDialogue()
-    AddInventoryEventFilter(libs.SoulgemFilled)
     If akActor.WornHasKeyword(libs.zad_DeviousHobbleSkirt)
         Utility.SetINIBool("bDampenPlayerControls:Controls", false)
     Endif
@@ -122,22 +128,12 @@ Event OnPlayerLoadGame()
     endif
     Game.UpdateHairColor()
     RegisterEvents()
-	RegisterForMenu("MapMenu")
     InitGagSpeak(false)
 EndEvent
 
 Function CheckForSoftDepends()
-	If Game.IsPluginInstalled("OSLAroused.esp")
-		libs.config.GotOSLA = True 		;OSL Aroused is here
-	Else
-		libs.config.GotOSLA = False     ;not here
-	EndIf
-
-	If Game.IsPluginInstalled("SexLab Inflation Framework.esp")
-		libs.config.GotSLIF = True  ;SexLab Inflation Framework is here
-	Else
-		libs.config.GotSLIF = False ;not here
-	EndIf
+	libs.config.GotOSLA = Game.IsPluginInstalled("OSLAroused.esp")
+	libs.config.GotSLIF = Game.IsPluginInstalled("SexLab Inflation Framework.esp")
 
 	If Game.IsPluginInstalled("DD_Animation_Overhaul_by_Taki17.esp")
 		libs.Error("DDNG: 'DD_Animation_Overhaul_by_Taki17' ESP is active. This ESP is from and old version and no longer required will cause issues. Remove the ESP from your mod manager.")
@@ -145,18 +141,16 @@ Function CheckForSoftDepends()
 EndFunction
  
 Event OnItemRemoved(Form akBaseItem, int aiItemCount, ObjectReference akItemReference, ObjectReference akDestContainer)
-    if akBaseItem == libs.SoulgemFilled
-        ; Replace with base item.
-        If akItemReference != None && akDestContainer == None  ; Dropped
-            libs.Log("Rechargeable soulgem removed: In world. Doing nothing.")
-        ElseIf akDestContainer != None && (akDestContainer as Actor) != libs.PlayerRef ; Gave item to NPC.
-            libs.Log("Rechargeable soulgem removed: Gave to an NPC, or stored in a chest.")
-        Else
-            libs.Log("Rechargeable soulgem removed: Used up. Replacing with empty.")
-            libs.playerRef.AddItem(libs.SoulgemEmpty, 1, true)
-            if akItemReference
-                akItemReference.Delete()
-            EndIf
+    ; Replace with base item.
+    If akItemReference != None && akDestContainer == None  ; Dropped
+        libs.Log("Rechargeable soulgem removed: In world. Doing nothing.")
+    ElseIf akDestContainer != None && (akDestContainer as Actor) != libs.PlayerRef ; Gave item to NPC.
+        libs.Log("Rechargeable soulgem removed: Gave to an NPC, or stored in a chest.")
+    Else
+        libs.Log("Rechargeable soulgem removed: Used up. Replacing with empty.")
+        libs.playerRef.AddItem(libs.SoulgemEmpty, 1, true)
+        if akItemReference
+            akItemReference.Delete()
         EndIf
     EndIf
 EndEvent
@@ -209,23 +203,16 @@ Event OnLocationChange(Location akOldLoc, Location akNewLoc)
 EndEvent
  
 bool Function isDeviousDevice(Form device)
-    if device.HasKeyword(libs.zad_InventoryDevice) || device.HasKeyword(libs.zad_Lockable) || device.HasKeyword(libs.zad_DeviousPlug)
-        return true
-    endif
-    return false
+    return device.HasKeyword(libs.zad_InventoryDevice) || device.HasKeyword(libs.zad_Lockable) || device.HasKeyword(libs.zad_DeviousPlug)
 EndFunction
 
 bool Function isStrapOn(Form device)
-    if device.HasKeyword(SexLabNoStrip) && device.HasKeyword(ArmorJewelry) 
-        return true
-    endif
-    return false
+    return device.HasKeyword(SexLabNoStrip) && device.HasKeyword(ArmorJewelry)
 EndFunction
  
 Event OnObjectEquipped(Form akBaseObject, ObjectReference akReference)
-    actor akActor = libs.PlayerRef
-    if akBaseObject as Armor
-        armor akArmor = (akBaseObject as Armor)
+    armor akArmor = (akBaseObject as Armor)
+    if akArmor != None
         if Math.LogicalAnd(akArmor.GetSlotMask(), 0x00000004) && !akArmor.HasKeyword(libs.zad_DeviousHarness)
             if libs.PlayerRef.WornHasKeyword(libs.zad_DeviousBra) &&  libs.PlayerRef.HasMagicEffectWithKeyword(libs.zad_EffectCompressBreasts)
                 libs.ShowBreasts(libs.PlayerRef)
@@ -236,9 +223,9 @@ Event OnObjectEquipped(Form akBaseObject, ObjectReference akReference)
         EndIf
     EndIf
     ;Allow script-equipped items through as long as they're not weapons, spells or torches
-    if !Utility.IsInMenuMode() && !((akBaseObject as Weapon) || (akBaseObject as Spell) || (akBaseObject as Light))
-        Return
-    EndIf
+    ;if !Utility.IsInMenuMode() && !((akBaseObject as Weapon) || (akBaseObject as Spell) || (akBaseObject as Light))
+    ;    Return
+    ;EndIf
     ;If akActor.WornHasKeyword(libs.zad_DeviousHeavyBondage) && ((akBaseObject as Weapon) || (akBaseObject as Spell) || (akBaseObject as Light) || ((akBaseObject as Armor) && (!isDeviousDevice(akBaseObject) && !isStrapOn(akBaseObject))))
     ;    If UI.IsMenuOpen("InventoryMenu")
     ;        libs.notify("You can't equip this with your hands tied!")
@@ -252,9 +239,8 @@ EndEvent
  
  
 Event OnObjectUnequipped(Form akBaseObject, ObjectReference akReference)
-    actor akActor = libs.PlayerRef
-    if akBaseObject as Armor
-        armor akArmor = (akBaseObject as Armor)
+    armor akArmor = (akBaseObject as Armor)
+    if akArmor != None
         if Math.LogicalAnd(akArmor.GetSlotMask(), 0x00000004)
             if !akArmor.HasKeyword(libs.zad_DeviousBra) && libs.PlayerRef.WornHasKeyword(libs.zad_DeviousBra) && libs.PlayerRef.HasMagicEffectWithKeyword(libs.zad_EffectCompressBreasts)
                 libs.HideBreasts(libs.PlayerRef)
@@ -267,7 +253,7 @@ Event OnObjectUnequipped(Form akBaseObject, ObjectReference akReference)
 EndEvent
 
 Event OnMenuOpen(String MenuName)
-	If libs.config.BlindfoldBlockMapUse && MenuName == "MapMenu" && libs.PlayerRef.WornHasKeyword(libs.zad_DeviousBlindfold)
+	If libs.config.BlindfoldBlockMapUse && libs.PlayerRef.WornHasKeyword(libs.zad_DeviousBlindfold)
         ; Tiny wait, then disable abMenu player controls, which will close the map menu.
 		Utility.WaitMenuMode(0.05)
 		Game.DisablePlayerControls(false, false, false, false, false, true, false, false)

--- a/dist/scripts/source/zadPlayerScript.psc
+++ b/dist/scripts/source/zadPlayerScript.psc
@@ -128,6 +128,7 @@ Event OnPlayerLoadGame()
         libs.MuteOverEncumberedMSG()
     endif
     Game.UpdateHairColor()
+    UnregisterForAllMenus()
     RegisterForMenu("MapMenu")
     RegisterEvents()
     RegisterKeys()

--- a/dist/scripts/source/zadPlugScript.psc
+++ b/dist/scripts/source/zadPlugScript.psc
@@ -109,10 +109,10 @@ Function RemovePlugNoLock()
 		EndIf
 		return
 	EndIf
-	if deviceRendered.HasKeyword(libs.zad_kw_InflatablePlugVaginal) && (libs.zadInflatablePlugStateVaginal.GetValueInt() > 0)
+	if deviceRendered.HasKeyword(libs.zad_kw_InflatablePlugVaginal) && (libs.zadInflatablePlugStateVaginal.GetValue() > 0)
 		libs.notify("You cannot remove this plug as long as it is inflated.", messagebox = true)
 		return
-	elseif deviceRendered.HasKeyword(libs.zad_kw_InflatablePlugAnal) && (libs.zadInflatablePlugStateAnal.GetValueInt() > 0)
+	elseif deviceRendered.HasKeyword(libs.zad_kw_InflatablePlugAnal) && (libs.zadInflatablePlugStateAnal.GetValue() > 0)
 		libs.notify("You cannot remove this plug as long as it is inflated.", messagebox = true)
 		return
 	EndIf
@@ -140,10 +140,10 @@ Function RemovePlugLock()
 		EndIf
 		return
 	EndIf
-	if deviceRendered.HasKeyword(libs.zad_kw_InflatablePlugVaginal) && (libs.zadInflatablePlugStateVaginal.GetValueInt() > 0)
+	if deviceRendered.HasKeyword(libs.zad_kw_InflatablePlugVaginal) && (libs.zadInflatablePlugStateVaginal.GetValue() > 0)
 		libs.notify("You cannot remove this plug as long as it is inflated.", messagebox = true)
 		return
-	elseif deviceRendered.HasKeyword(libs.zad_kw_InflatablePlugAnal) && (libs.zadInflatablePlugStateAnal.GetValueInt() > 0)
+	elseif deviceRendered.HasKeyword(libs.zad_kw_InflatablePlugAnal) && (libs.zadInflatablePlugStateAnal.GetValue() > 0)
 		libs.notify("You cannot remove this plug as long as it is inflated.", messagebox = true)
 		return
 	EndIf

--- a/dist/scripts/source/zadPlugScript.psc
+++ b/dist/scripts/source/zadPlugScript.psc
@@ -83,16 +83,7 @@ Function OnEquippedPre(actor akActor, bool silent=false)
 	EndIf
 EndFunction
 
-
 Function OnEquippedPost(actor akActor)
-	Utility.Wait(5)
-	bool legacyPlugs = false
-	; Slots 48 and 57 Anal and Vaginal plugs      
-	Form analSlot = akActor.GetWornForm(0x00040000)
-	Form vagSlot = akActor.GetWornForm(0x08000000)
-	if analSlot && vagSlot && analSlot == vagSlot
-		legacyPlugs = true
-	EndIf
 EndFunction
 
 Function RemovePlugNoLock()

--- a/dist/scripts/source/zadPlugScript.psc
+++ b/dist/scripts/source/zadPlugScript.psc
@@ -26,14 +26,12 @@ int Function OnEquippedFilter(actor akActor, bool silent=false)
 			; open belts allow putting in anal plugs.
 			return 0
 		EndIf
-		if akActor == libs.PlayerRef && !silent
-			libs.NotifyActor(strFailEquipBelt, akActor, true)
-		ElseIf  !silent
-			libs.NotifyActor("The belt " + akActor.GetLeveledActorBase().GetName() + " is wearing prevents you from inserting this plug.", akActor, true)
-		EndIf
 		if !silent
-			return 2
-		Else
+			If akActor == libs.PlayerRef
+				libs.NotifyActor(strFailEquipBelt, akActor, true)
+			Else
+				libs.NotifyActor("The belt " + akActor.GetLeveledActorBase().GetName() + " is wearing prevents you from inserting this plug.", akActor, true)
+			EndIf
 			return 0
 		EndIf
 	Endif
@@ -51,11 +49,12 @@ Function OnEquippedPre(actor akActor, bool silent=false)
 	string msg = ""
 	If !deviceKey
 		if akActor == libs.PlayerRef
-			if Aroused.GetActorExposure(akActor) < libs.ArousalThreshold("Desire")
+			Int exposure = Aroused.GetActorExposure(akActor)
+			if exposure < libs.ArousalThreshold("Desire")
 				msg = "Your hole is now filled, as is your desire for pleasure."
-			elseif Aroused.GetActorExposure(akActor) < libs.ArousalThreshold("Horny")
+			elseif exposure < libs.ArousalThreshold("Horny")
 				msg = "You slowly insert the plug inside your opening, your lust growing with every inch it slides in."
-			elseif Aroused.GetActorExposure(akActor) < libs.ArousalThreshold("Desperate")
+			elseif exposure < libs.ArousalThreshold("Desperate")
 				msg = "You insert the plug inside your opening and take great delight in the resulting feelings of pleasure."
 			else
 				msg = "Barely in control of control your own body you thrust the plug almost forcefully into the appropriate opening."
@@ -65,11 +64,12 @@ Function OnEquippedPre(actor akActor, bool silent=false)
 		EndIf
 	Else
 		if akActor == libs.PlayerRef
-			if Aroused.GetActorExposure(akActor) < libs.ArousalThreshold("Desire")
+			Int exposure = Aroused.GetActorExposure(akActor)
+			if exposure < libs.ArousalThreshold("Desire")
 				msg = "As you gently slide the plug in, you hear a sharp click and suddenly feel very full."
-			elseif Aroused.GetActorExposure(akActor) < libs.ArousalThreshold("Horny")
+			elseif exposure < libs.ArousalThreshold("Horny")
 				msg = "You slowly push the plug into your hole and let out a quiet gasp when it expands, locking itself securely in place."
-			elseif Aroused.GetActorExposure(akActor) < libs.ArousalThreshold("Desperate")
+			elseif exposure < libs.ArousalThreshold("Desperate")
 				msg = "You insert the plug inside your sensitive opening and it clicks, suddenly growing in volume and filling you with delight."
 			else
 				msg = "You impatiently thrust the plug deep into yourself and its rapid expansion makes your legs clench together instinctively."
@@ -108,11 +108,12 @@ Function RemovePlugNoLock()
 		return
 	EndIf
 	string msg = ""
-	if Aroused.GetActorExposure(libs.PlayerRef) < libs.ArousalThreshold("Desire")
+	Int exposure = Aroused.GetActorExposure(libs.PlayerRef)
+	if exposure < libs.ArousalThreshold("Desire")
 		msg = "You easily slide the plug out of your hole and feel no regret."
-	elseif Aroused.GetActorExposure(libs.PlayerRef) < libs.ArousalThreshold("Horny")
+	elseif exposure < libs.ArousalThreshold("Horny")
 		msg = "Despite the pleasure it provides, you remove the plug from your hole."
-	elseif Aroused.GetActorExposure(libs.PlayerRef) < libs.ArousalThreshold("Desperate")
+	elseif exposure < libs.ArousalThreshold("Desperate")
 		msg = "Despite your body telling you otherwise, you reluctantly pull the plug from your now well lubricated opening."
 	else
 		msg = "It takes all the willpower that you can muster to relax your muscles enough to let the plug slide out."
@@ -140,11 +141,12 @@ Function RemovePlugLock()
 	EndIf
 	string msg = ""	
 	if RemoveDeviceWithKey() 
-		if Aroused.GetActorExposure(libs.PlayerRef) < libs.ArousalThreshold("Desire")
+		Int exposure = Aroused.GetActorExposure(libs.PlayerRef)
+		if exposure < libs.ArousalThreshold("Desire")
 			msg = "You unlock the plug and it contracts, allowing you to remove it without much hassle."
-		elseif Aroused.GetActorExposure(libs.PlayerRef) < libs.ArousalThreshold("Horny")
+		elseif exposure < libs.ArousalThreshold("Horny")
 			msg = "The mechanism rumbles as it reduces the plug to a more manageable size and you slowly pull it out."
-		elseif Aroused.GetActorExposure(libs.PlayerRef) < libs.ArousalThreshold("Desperate")
+		elseif exposure < libs.ArousalThreshold("Desperate")
 			msg = "You turn the key very slowly to ease your body into letting the plug go and feel a tinge of regret as you slide it out."
 		else
 			msg = "It takes all the focus you can muster to properly disengage the plug's locking mechanism, but once you do it practically falls out of your lubricated opening."

--- a/dist/scripts/source/zadTrainingEffect.psc
+++ b/dist/scripts/source/zadTrainingEffect.psc
@@ -34,7 +34,7 @@ Event OnTrainingViolation(string eventName, string argString, float argNum, form
 	if argString == "SpellCast"
 		ModDaysRemaining(1, maxRange=GetTrainingRange())
 		libs.NotifyPlayer("Your mental reserves are dramatically drained as the plug punishes you.")
-		libs.PlayerRef.DamageAv("Magicka", 200)
+		libs.PlayerRef.DamageActorValue("Magicka", 200)
 	EndIf
 EndEvent
 

--- a/dist/scripts/source/zadTrainingEffect.psc
+++ b/dist/scripts/source/zadTrainingEffect.psc
@@ -4,8 +4,8 @@ ScriptName zadTrainingEffect extends ActiveMagicEffect
 zadLibs Property Libs Auto
 SexlabFramework Property Sexlab Auto
 
-Bool Property Terminate Auto
-actor Property Target Auto
+Bool Terminate
+actor Target
 
 ; Extend this function to set a day passed event.
 Function OnTrainingDayPassed(int daysRemaining)
@@ -97,7 +97,6 @@ Event OnEffectStart(Actor akTarget, Actor akCaster)
 		libs.Log("OnEffectStart(Training): Not player, doing nothing.")
 	else
 		libs.Log("OnEffectStart(Training)")
-		Terminate = False
 		DoRegisterModEvent()
 		DoRegister()
 	EndIf

--- a/dist/scripts/source/zadTrainingEffect.psc
+++ b/dist/scripts/source/zadTrainingEffect.psc
@@ -34,7 +34,7 @@ Event OnTrainingViolation(string eventName, string argString, float argNum, form
 	if argString == "SpellCast"
 		ModDaysRemaining(1, maxRange=GetTrainingRange())
 		libs.NotifyPlayer("Your mental reserves are dramatically drained as the plug punishes you.")
-		libs.PlayerRef.DamageActorValue("Magicka", 200)
+		Target.DamageActorValue("Magicka", 200)
 	EndIf
 EndEvent
 
@@ -50,20 +50,21 @@ Event OnUpdateGameTime()
 	EndIf
 EndEvent
 
-float Function InitNextTickTime()
-	float ret = libs.GameDaysPassed.GetValue() + 1.0
+float Function InitNextTickTime(Float daysPassed)
+	float ret = daysPassed + 1.0
 	StorageUtil.SetFloatValue(Target, "zad.NextTickTime", ret)
 	return ret
 EndFunction
 
 Function DoRegister()
+	Float time = libs.GameDaysPassed.GetValue()
 	float nextTime = StorageUtil.GetFloatValue(Target, "zad.NextTickTime", -1.0)
 	if nextTime == -1.0
-		nextTime = InitNextTickTime()
+		nextTime = InitNextTickTime(time)
 	EndIf
-	libs.Log("DoRegister(Training):"+libs.GameDaysPassed.GetValue()+" / "+ nextTime)
-	if !Terminate && libs.GameDaysPassed.GetValue() >= nextTime
-		InitNextTickTime()
+	libs.Log("DoRegister(Training):"+time+" / "+ nextTime)
+	if !Terminate && time >= nextTime
+		InitNextTickTime(time)
 		int daysRemaining = ModDaysRemaining(-1, maxRange=GetTrainingRange())
 		libs.Log("DoRegister(Training): Day passed. Days Remaining: "+daysRemaining +".")
 		if daysRemaining == 0
@@ -81,11 +82,10 @@ int Function ModDaysRemaining(int changeBy, int maxRange)
 	int newDaysRemaining = daysRemaining + changeBy
 	if newDaysRemaining <0
 		newDaysRemaining = 0
-	EndIf
-	if newDaysRemaining > maxRange
+	elseif newDaysRemaining > maxRange
 		newDaysRemaining = maxRange
 	EndIf
-	InitNextTickTime()
+	InitNextTickTime(libs.GameDaysPassed.GetValue())
 	libs.log("Days remaining was: "+daysRemaining+". Now set to "+newDaysRemaining+".")
 	StorageUtil.SetIntValue(Target, "zad.TrainingDaysRemaining", newDaysRemaining)
 	return newDaysRemaining
@@ -104,8 +104,6 @@ EndEvent
 
 Event OnEffectFinish(Actor akTarget, Actor akCaster)
 	Terminate = True
-	UnregisterForModEvent("TrainingViolation")
-	UnregisterForUpdateGameTime()
 	libs.Log("OnEffectFinish(Training)")
 EndEvent
 

--- a/dist/scripts/source/zad_EffInflatablePlugsAnalScript.psc
+++ b/dist/scripts/source/zad_EffInflatablePlugsAnalScript.psc
@@ -69,8 +69,8 @@ endfunction
 
 Event OnUpdate()	
 	if !Terminate
-		If (libs.GameDaysPassed.GetValue() - libs.LastInflationAdjustmentAnal) * 24.0 > 5.0 && (libs.zadInflatablePlugStateAnal.GetValueInt() > 0)
-			libs.zadInflatablePlugStateAnal.SetValueInt(libs.zadInflatablePlugStateAnal.GetValueInt() - 1)
+		If (libs.GameDaysPassed.GetValue() - libs.LastInflationAdjustmentAnal) * 24.0 > 5.0 && (libs.zadInflatablePlugStateAnal.GetValue() > 0)
+			libs.zadInflatablePlugStateAnal.SetValue(libs.zadInflatablePlugStateAnal.GetValue() - 1)
 			libs.notify("Your inflatable plugs lose some pressure...")
 			libs.LastInflationAdjustmentAnal = libs.GameDaysPassed.GetValue()
 			DoRegister()
@@ -105,7 +105,7 @@ Event OnEffectStart(Actor akTarget, Actor akCaster)
 	EndIf
 	Target = akTarget
 	Terminate = False	
-	libs.zadInflatablePlugStateAnal.SetValueInt(0)
+	libs.zadInflatablePlugStateAnal.SetValue(0)
 	libs.LastInflationAdjustmentAnal = libs.GameDaysPassed.GetValue()
 	DoStart()
 EndEvent

--- a/dist/scripts/source/zad_EffInflatablePlugsAnalScript.psc
+++ b/dist/scripts/source/zad_EffInflatablePlugsAnalScript.psc
@@ -43,55 +43,49 @@ Function DoUnregister()
 	EndIf	
 EndFunction
 
-bool Function isInHomeorJail()
-	Location loc = libs.PlayerRef.GetCurrentLocation()
-    if loc != none && (loc.haskeyword(loctypeplayerhome) || loc.haskeyword(loctypejail) ) 
-        return true
-    endif    
-    return false
+bool Function isInHomeorJail(Location loc)
+	Return loc != none && (loc.haskeyword(loctypeplayerhome) || loc.haskeyword(loctypejail) ) 
 endfunction
 
-bool Function isInCity()
-	Location loc = libs.PlayerRef.GetCurrentLocation()
-    if loc != none && (loc.haskeyword(loctypecity) || loc.haskeyword(loctypetown) || loc.haskeyword(loctypehabitation) || loc.haskeyword(loctypedwelling))        
-        return true
-    endif    
-    return false
+bool Function isInCity(Location loc)
+	Return loc != none && (loc.haskeyword(loctypecity) || loc.haskeyword(loctypetown) || loc.haskeyword(loctypehabitation) || loc.haskeyword(loctypedwelling))
 endfunction
 
-bool Function isInHold()  
-	Location loc = libs.PlayerRef.GetCurrentLocation() 
-    if !libs.PlayerRef.GetParentCell().IsInterior() && (loc == none || loc.haskeyword(loctypehold))
-        return true
-    endif    
-    return false
+bool Function isInHold(Location loc)  
+	Return !Target.GetParentCell().IsInterior() && (loc == none || loc.haskeyword(loctypehold))
 endfunction
 
 Event OnUpdate()	
 	if !Terminate
-		If (libs.GameDaysPassed.GetValue() - libs.LastInflationAdjustmentAnal) * 24.0 > 5.0 && (libs.zadInflatablePlugStateAnal.GetValue() > 0)
-			libs.zadInflatablePlugStateAnal.SetValue(libs.zadInflatablePlugStateAnal.GetValue() - 1)
-			libs.notify("Your inflatable plugs lose some pressure...")
-			libs.LastInflationAdjustmentAnal = libs.GameDaysPassed.GetValue()
-			DoRegister()
-			return
+		Float day = (libs.GameDaysPassed.GetValue() - libs.LastInflationAdjustmentAnal) * 24.0
+		If day > 5.0
+			Float plugState = libs.zadInflatablePlugStateAnal.GetValue()
+			If (plugState > 0)
+				libs.zadInflatablePlugStateAnal.SetValue(plugState - 1)
+				libs.notify("Your inflatable plugs lose some pressure...")
+				libs.LastInflationAdjustmentAnal = libs.GameDaysPassed.GetValue()
+				DoRegister()
+				return
+			EndIf
 		EndIf
-		if !libs.playerRef.IsInCombat() && !libs.IsAnimating(libs.playerRef) && !libs.playerref.IsOnMount() && !libs.playerref.IsSwimming() && !isInHomeorJail() && (isInCity() || isInHold()) && !UI.IsMenuOpen("Dialogue Menu")
-			; look for people that 'accidentally' inflate the plugs
-			If Utility.RandomInt() < 25 && (libs.GameDaysPassed.GetValue() - libs.LastInflationAdjustmentAnal) * 24.0 > 1.0 ; can't happen more than once in a while
-				libs.log("Inflatable Plugs: Testing for valid NPC.")
-				Actor currenttest		
-				currenttest = Game.FindRandomActorFromRef(libs.playerRef, 350.0)
-				if currenttest && libs.ValidForInteraction(currenttest, genderreq = -1, creatureok = false, animalok = false, beastreaceok = true, elderok = true, guardok = true)
-					libs.notify(currenttest.GetActorBase().GetName() + " gives your plug pump a squeeze, inflating it inside you!")
-					libs.InflateRandomPlug(libs.playerref, 1)
-				ElseIf Utility.RandomInt() < 10 ; when there is nobody there, she has a small chance to do it herself:
-					libs.notify("You 'accidentally' give your plug pump a squeeze...")
-					libs.InflateRandomPlug(libs.playerref, 1)
+		if !Target.IsInCombat() && !libs.IsAnimating(Target) && !Target.IsOnMount() && !Target.IsSwimming()
+			Location loc = Target.GetCurrentLocation()
+			If !isInHomeorJail(loc) && (isInCity(loc) || isInHold(loc)) && !UI.IsMenuOpen("Dialogue Menu")
+				; look for people that 'accidentally' inflate the plugs
+				If Utility.RandomInt() < 25 && day > 1.0 ; can't happen more than once in a while
+					libs.log("Inflatable Plugs: Testing for valid NPC.")
+					Actor currenttest = Game.FindRandomActorFromRef(Target, 350.0)
+					if currenttest && libs.ValidForInteraction(currenttest, genderreq = -1, creatureok = false, animalok = false, beastreaceok = true, elderok = true, guardok = true)
+						libs.notify(currenttest.GetActorBase().GetName() + " gives your plug pump a squeeze, inflating it inside you!")
+						libs.InflateRandomPlug(Target, 1)
+					ElseIf Utility.RandomInt() < 10 ; when there is nobody there, she has a small chance to do it herself:
+						libs.notify("You 'accidentally' give your plug pump a squeeze...")
+						libs.InflateRandomPlug(Target, 1)
+					EndIf
 				EndIf
 			EndIf
 		EndIf
-		libs.Aroused.UpdateActorExposure(libs.PlayerRef, 2)
+		libs.Aroused.UpdateActorExposure(Target, 2)
 	Else ; Avoid race condition		
 	EndIf	
 	DoRegister()

--- a/dist/scripts/source/zad_EffInflatablePlugsAnalScript.psc
+++ b/dist/scripts/source/zad_EffInflatablePlugsAnalScript.psc
@@ -110,5 +110,4 @@ Event OnEffectFinish(Actor akTarget, Actor akCaster)
 		return
 	EndIf
 	Terminate = True
-	DoUnregister()
 EndEvent

--- a/dist/scripts/source/zad_EffInflatablePlugsAnalScript.psc
+++ b/dist/scripts/source/zad_EffInflatablePlugsAnalScript.psc
@@ -2,8 +2,8 @@ Scriptname zad_EffInflatablePlugsAnalScript extends activemagiceffect
 
 zadLibs Property Libs Auto
 
-Actor Property target Auto Hidden
-bool Property Terminate Auto Hidden
+Actor target
+bool Terminate
 
 ; Global properties are declared here for convenience
 Keyword Property loctypeplayerhome Auto

--- a/dist/scripts/source/zad_EffInflateableVaginalPlugScript.psc
+++ b/dist/scripts/source/zad_EffInflateableVaginalPlugScript.psc
@@ -2,8 +2,8 @@ Scriptname zad_EffInflateableVaginalPlugScript extends activemagiceffect
 
 zadLibs Property Libs Auto
 
-Actor Property target Auto Hidden
-bool Property Terminate Auto Hidden
+Actor target
+bool Terminate
 
 ; Global properties are declared here for convenience
 Keyword Property loctypeplayerhome Auto

--- a/dist/scripts/source/zad_EffInflateableVaginalPlugScript.psc
+++ b/dist/scripts/source/zad_EffInflateableVaginalPlugScript.psc
@@ -69,8 +69,8 @@ endfunction
 
 Event OnUpdate()	
 	if !Terminate
-		If (libs.GameDaysPassed.GetValue() - libs.LastInflationAdjustmentVaginal) * 24.0 > 5.0 && (libs.zadInflatablePlugStateVaginal.GetValueInt() > 0)
-			libs.zadInflatablePlugStateVaginal.SetValueInt(libs.zadInflatablePlugStateVaginal.GetValueInt() - 1)
+		If (libs.GameDaysPassed.GetValue() - libs.LastInflationAdjustmentVaginal) * 24.0 > 5.0 && (libs.zadInflatablePlugStateVaginal.GetValue() > 0)
+			libs.zadInflatablePlugStateVaginal.SetValue(libs.zadInflatablePlugStateVaginal.GetValue() - 1)
 			libs.notify("Your inflatable plugs lose some pressure...")
 			libs.LastInflationAdjustmentVaginal = libs.GameDaysPassed.GetValue()
 			DoRegister()
@@ -105,7 +105,7 @@ Event OnEffectStart(Actor akTarget, Actor akCaster)
 	EndIf
 	Target = akTarget
 	Terminate = False	
-	libs.zadInflatablePlugStateVaginal.SetValueInt(0)
+	libs.zadInflatablePlugStateVaginal.SetValue(0)
 	libs.LastInflationAdjustmentVaginal = libs.GameDaysPassed.GetValue()
 	DoStart()
 EndEvent

--- a/dist/scripts/source/zad_EffInflateableVaginalPlugScript.psc
+++ b/dist/scripts/source/zad_EffInflateableVaginalPlugScript.psc
@@ -110,5 +110,4 @@ Event OnEffectFinish(Actor akTarget, Actor akCaster)
 		return
 	EndIf
 	Terminate = True
-	DoUnregister()
 EndEvent

--- a/dist/scripts/source/zad_EffInflateableVaginalPlugScript.psc
+++ b/dist/scripts/source/zad_EffInflateableVaginalPlugScript.psc
@@ -43,55 +43,49 @@ Function DoUnregister()
 	EndIf	
 EndFunction
 
-bool Function isInHomeorJail()
-	Location loc = libs.PlayerRef.GetCurrentLocation()
-    if loc != none && (loc.haskeyword(loctypeplayerhome) || loc.haskeyword(loctypejail) ) 
-        return true
-    endif    
-    return false
+bool Function isInHomeorJail(Location loc)
+	return loc != none && (loc.haskeyword(loctypeplayerhome) || loc.haskeyword(loctypejail) )
 endfunction
 
-bool Function isInCity()
-	Location loc = libs.PlayerRef.GetCurrentLocation()
-    if loc != none && (loc.haskeyword(loctypecity) || loc.haskeyword(loctypetown) || loc.haskeyword(loctypehabitation) || loc.haskeyword(loctypedwelling))        
-        return true
-    endif    
-    return false
+bool Function isInCity(Location loc)
+	return loc != none && (loc.haskeyword(loctypecity) || loc.haskeyword(loctypetown) || loc.haskeyword(loctypehabitation) || loc.haskeyword(loctypedwelling))
 endfunction
 
-bool Function isInHold()  
-	Location loc = libs.PlayerRef.GetCurrentLocation() 
-    if !libs.PlayerRef.GetParentCell().IsInterior() && (loc == none || loc.haskeyword(loctypehold))
-        return true
-    endif    
-    return false
+bool Function isInHold(Location loc)  
+	return !Target.GetParentCell().IsInterior() && (loc == none || loc.haskeyword(loctypehold))
 endfunction
 
 Event OnUpdate()	
 	if !Terminate
-		If (libs.GameDaysPassed.GetValue() - libs.LastInflationAdjustmentVaginal) * 24.0 > 5.0 && (libs.zadInflatablePlugStateVaginal.GetValue() > 0)
-			libs.zadInflatablePlugStateVaginal.SetValue(libs.zadInflatablePlugStateVaginal.GetValue() - 1)
-			libs.notify("Your inflatable plugs lose some pressure...")
-			libs.LastInflationAdjustmentVaginal = libs.GameDaysPassed.GetValue()
-			DoRegister()
-			return
+		Float day = (libs.GameDaysPassed.GetValue() - libs.LastInflationAdjustmentVaginal) * 24.0
+		If day > 5.0
+			Float plugState = libs.zadInflatablePlugStateVaginal.GetValue()
+			If (plugState > 0)
+				libs.zadInflatablePlugStateVaginal.SetValue(plugState - 1)
+				libs.notify("Your inflatable plugs lose some pressure...")
+				libs.LastInflationAdjustmentVaginal = libs.GameDaysPassed.GetValue()
+				DoRegister()
+				return
+			EndIf
 		EndIf
-		if !libs.playerRef.IsInCombat() && !libs.IsAnimating(libs.playerRef) && !libs.playerref.IsOnMount() && !libs.playerref.IsSwimming() && !isInHomeorJail() && (isInCity() || isInHold()) && !UI.IsMenuOpen("Dialogue Menu")
-			; look for people that 'accidentally' inflate the plugs
-			If Utility.RandomInt() < 25 && (libs.GameDaysPassed.GetValue() - libs.LastInflationAdjustmentVaginal) * 24.0 > 1.0 ; can't happen more than once in a while
-				libs.log("Inflatable Plugs: Testing for valid NPC.")
-				Actor currenttest		
-				currenttest = Game.FindRandomActorFromRef(libs.playerRef, 350.0)
-				if currenttest && libs.ValidForInteraction(currenttest, genderreq = -1, creatureok = false, animalok = false, beastreaceok = true, elderok = true, guardok = true)
-					libs.notify(currenttest.GetActorBase().GetName() + " gives your plug pump a squeeze, inflating it inside you!")
-					libs.InflateRandomPlug(libs.playerref, 1)
-				ElseIf Utility.RandomInt() < 10 ; when there is nobody there, she has a small chance to do it herself:
-					libs.notify("You 'accidentally' give your plug pump a squeeze...")
-					libs.InflateRandomPlug(libs.playerref, 1)				
+		if !Target.IsInCombat() && !libs.IsAnimating(Target) && !Target.IsOnMount() && !Target.IsSwimming()
+			Location loc = Target.GetCurrentLocation()
+			If !isInHomeorJail(loc) && (isInCity(loc) || isInHold(loc)) && !UI.IsMenuOpen("Dialogue Menu")
+				; look for people that 'accidentally' inflate the plugs
+				If Utility.RandomInt() < 25 && day > 1.0 ; can't happen more than once in a while
+					libs.log("Inflatable Plugs: Testing for valid NPC.")
+					Actor currenttest = Game.FindRandomActorFromRef(Target, 350.0)
+					if currenttest && libs.ValidForInteraction(currenttest, genderreq = -1, creatureok = false, animalok = false, beastreaceok = true, elderok = true, guardok = true)
+						libs.notify(currenttest.GetActorBase().GetName() + " gives your plug pump a squeeze, inflating it inside you!")
+						libs.InflateRandomPlug(Target, 1)
+					ElseIf Utility.RandomInt() < 10 ; when there is nobody there, she has a small chance to do it herself:
+						libs.notify("You 'accidentally' give your plug pump a squeeze...")
+						libs.InflateRandomPlug(Target, 1)				
+					EndIf
 				EndIf
 			EndIf
 		EndIf
-		libs.Aroused.UpdateActorExposure(libs.PlayerRef, 2)
+		libs.Aroused.UpdateActorExposure(Target, 2)
 	Else ; Avoid race condition
 	EndIf	
 	DoRegister()

--- a/dist/scripts/source/zadcFurnitureScript.psc
+++ b/dist/scripts/source/zadcFurnitureScript.psc
@@ -369,7 +369,7 @@ Function UnlockActor()
 	user.StopTranslation()
 	ActorUtil.RemovePackageOverride(user, CurrentStruggle)
 	ActorUtil.RemovePackageOverride(user, CurrentPose)
-	If user == Game.GetPlayer()
+	If user == libs.PlayerRef
 		Game.SetPlayerAIDriven(False)
 		Game.EnablePlayerControls()	
 		user.RemoveItem(clib.zadc_NoWaitItem, user.GetItemCount(clib.zadc_NoWaitItem), abSilent = True)
@@ -1054,7 +1054,7 @@ Float Function CalculateDifficultyModifier(Bool operator = true)
 EndFunction
 
 Function DisplayDifficultyMsg()
-	Int StruggleEscapeChance = Math.Floor(BaseEscapeChance)
+	Int StruggleEscapeChance = BaseEscapeChance as Int
 	String result = "You carefully examine the " + DeviceName + ". "
 	If StruggleEscapeChance > 75
 		result += "This restraint is fairly weak and will not offer much resistance against struggling."
@@ -1182,7 +1182,7 @@ Bool Function Escape(Float Chance)
 	If Utility.RandomFloat(0.0, 99.9) < (Chance * CalculateDifficultyModifier(True))
 		libs.log("User has escaped " + DeviceName)
 		; increase success counter
-		libs.zadDeviceEscapeSuccessCount.SetValueInt(libs.zadDeviceEscapeSuccessCount.GetValueInt() + 1)				
+		libs.zadDeviceEscapeSuccessCount.SetValue(libs.zadDeviceEscapeSuccessCount.GetValue() + 1)				
 		;libs.SendDeviceEscapeEvent(DeviceInventory, zad_DeviousDevice, true)
 		return True
 	Else
@@ -1268,17 +1268,17 @@ Float Function CalclulateStruggleSuccess()
 		; add 1% for every previous attempt
 		result += EscapeStruggleAttemptsMade		
 		; apply strength bonus
-		If Libs.PlayerRef.GetAV("Stamina") > 25 
+		If Libs.PlayerRef.GetActorValue("Stamina") > 25 
 			result += 1.0
 		Endif
-		If Libs.PlayerRef.GetAV("Stamina") > 50
+		If Libs.PlayerRef.GetActorValue("Stamina") > 50
 			result += 2.0
 		Endif
-		If Libs.PlayerRef.GetAV("Stamina") > 75 
+		If Libs.PlayerRef.GetActorValue("Stamina") > 75 
 			result += 3.0
 		Endif		
 		; apply bonus for total successful escapes - shares that value with wearable restraints
-		Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValueInt()
+		Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue() as Int
 		If EscapesMade > 10
 			result += 1.0
 		Endif
@@ -1336,17 +1336,17 @@ Float Function CalclulateBreakSuccess()
 	If BreakDeviceEscapeChance > 0.0
 		; add 1% for every previous attempt
 		result += EscapeBreakAttemptsMade		
-		If Libs.PlayerRef.GetAV("OneHanded") > 25 || Libs.PlayerRef.GetAV("TwoHanded") > 25
+		If Libs.PlayerRef.GetActorValue("OneHanded") > 25 || Libs.PlayerRef.GetActorValue("TwoHanded") > 25
 			result += 1.0
 		Endif
-		If Libs.PlayerRef.GetAV("OneHanded") > 50 || Libs.PlayerRef.GetAV("TwoHanded") > 50
+		If Libs.PlayerRef.GetActorValue("OneHanded") > 50 || Libs.PlayerRef.GetActorValue("TwoHanded") > 50
 			result += 2.0
 		Endif
-		If Libs.PlayerRef.GetAV("OneHanded") > 75 || Libs.PlayerRef.GetAV("TwoHanded") > 75
+		If Libs.PlayerRef.GetActorValue("OneHanded") > 75 || Libs.PlayerRef.GetActorValue("TwoHanded") > 75
 			result += 3.0
 		Endif
 		; apply bonus for total successful escapes
-		Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValueInt()
+		Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue() as Int
 		If EscapesMade > 10
 			result += 1.0
 		Endif
@@ -1450,17 +1450,17 @@ Float Function CalclulateLockPickSuccess()
 	If LockPickEscapeChance > 0.0
 		; add 1% for every previous attempt
 		result += EscapeLockPickAttemptsMade		
-		If Libs.PlayerRef.GetAV("Lockpicking") > 25
+		If Libs.PlayerRef.GetActorValue("Lockpicking") > 25
 			result += 1.0
 		Endif
-		If Libs.PlayerRef.GetAV("Lockpicking") > 50
+		If Libs.PlayerRef.GetActorValue("Lockpicking") > 50
 			result += 2.0
 		Endif
-		If Libs.PlayerRef.GetAV("Lockpicking") > 75
+		If Libs.PlayerRef.GetActorValue("Lockpicking") > 75
 			result += 3.0
 		Endif
 		; apply bonus for total successful escapes
-		Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValueInt()
+		Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue() as Int
 		If EscapesMade > 10
 			result += 1.0
 		Endif

--- a/dist/scripts/source/zadcFurnitureScript.psc
+++ b/dist/scripts/source/zadcFurnitureScript.psc
@@ -227,7 +227,7 @@ Function ApplyDevices(Actor akActor)
 	While i > 0
 		i -= 1
 		If EquipDevices[i].HasKeyword(libs.zad_InventoryDevice)
-			libs.EquipDevice(akActor, EquipDevices[i], libs.GetRenderedDevice(EquipDevices[i]), libs.GetDeviceKeyword(EquipDevices[i]), SkipMutex = True, SkipEvents = False)
+			libs.EquipDevice(akActor, EquipDevices[i], zadNativeFunctions.GetRenderDevice(EquipDevices[i]) as Armor, libs.GetDeviceKeyword(EquipDevices[i]), SkipMutex = True, SkipEvents = False)
 		Else
 			akActor.EquipItem(EquipDevices[i], abSilent = True)
 		EndIf
@@ -239,7 +239,7 @@ Function RemoveDevices(Actor akActor)
 	While i > 0
 		i -= 1
 		If EquipDevices[i].HasKeyword(libs.zad_InventoryDevice)
-			libs.RemoveDevice(akActor, EquipDevices[i], libs.GetRenderedDevice(EquipDevices[i]), libs.GetDeviceKeyword(EquipDevices[i]), SkipMutex = True, SkipEvents = False, DestroyDevice = True)
+			libs.RemoveDevice(akActor, EquipDevices[i], zadNativeFunctions.GetRenderDevice(EquipDevices[i]) as Armor, libs.GetDeviceKeyword(EquipDevices[i]), SkipMutex = True, SkipEvents = False, DestroyDevice = True)
 		Else
 			akActor.UnEquipItem(EquipDevices[i], abSilent = True)
 			akActor.RemoveItem(EquipDevices[i], abSilent = True)
@@ -325,7 +325,7 @@ Function LockActor(actor act)
 			act.EquipItem(clib.zadc_NoWaitItem, True, True)
 		EndIf
 		Game.ForceThirdPerson()
-		Game.SetCameraTarget(libs.PlayerRef)
+		Game.SetCameraTarget(act)
 	EndIf			
 	clib.StoreDevice(user, self)
 	SetLockShield()	
@@ -826,7 +826,7 @@ Event OnDDCSLEnd(int tid, bool hasPlayer)
         Game.SetPlayerAIDriven()
         Game.DisablePlayerControls(abMovement = true, abFighting = true, abSneaking = true, abMenu = true,    abActivate = false, abCamSwitch = false, abLooking = false, abJournalTabs = true)
         Game.ForceThirdPerson()
-        Game.SetCameraTarget(libs.PlayerRef)
+        Game.SetCameraTarget(User)
     Else
         User.SetDontMove(True)
         User.SetRestrained(True)
@@ -849,7 +849,7 @@ Function MoveToBehind(ObjectReference akObjB, ObjectReference akObjA, Float afDi
 		Utility.wait(0.1)
 	elseif user == libs.PlayerRef
 		;akObjA.SetAngle(akObjA.GetAngleX(), akObjA.GetAngleY(), akObject.GetAngleZ()) 
-		libs.PlayerRef.SetAngle(libs.PlayerRef.GetAngleX(), libs.PlayerRef.GetAngleY(), libs.PlayerRef.GetAngleZ() + 180.0) ; rotate the player 180 degrees so the anim starts at the correct rotation
+		user.SetAngle(user.GetAngleX(), user.GetAngleY(), user.GetAngleZ() + 180.0) ; rotate the player 180 degrees so the anim starts at the correct rotation
 		Utility.wait(0.1)
 	endif
 EndFunction
@@ -860,7 +860,7 @@ Function MoveToFront(ObjectReference akObjB, ObjectReference akObjA, Float afDis
 			akObjA.SetAngle(akObjB.GetAngleX(), akObjB.GetAngleY(), akObjB.GetAngleZ())
 			akObjA.SetAngle(akObjA.GetAngleX(), akObjA.GetAngleY(), akObjA.GetAngleZ() + 180.0) 
 		elseif user == libs.PlayerRef
-			libs.PlayerRef.SetAngle(libs.PlayerRef.GetAngleX(), libs.PlayerRef.GetAngleY(), libs.PlayerRef.GetAngleZ() + 180.0) 
+			user.SetAngle(user.GetAngleX(), user.GetAngleY(), user.GetAngleZ() + 180.0) 
 			Utility.wait(0.1)
 		Endif
 EndFunction

--- a/dist/scripts/source/zadcFurnitureScript.psc
+++ b/dist/scripts/source/zadcFurnitureScript.psc
@@ -227,7 +227,7 @@ Function ApplyDevices(Actor akActor)
 	While i > 0
 		i -= 1
 		If EquipDevices[i].HasKeyword(libs.zad_InventoryDevice)
-			libs.EquipDevice(akActor, EquipDevices[i], zadNativeFunctions.GetRenderDevice(EquipDevices[i]) as Armor, libs.GetDeviceKeyword(EquipDevices[i]), SkipMutex = True, SkipEvents = False)
+			libs.EquipDevice(akActor, EquipDevices[i], zadNativeFunctions.GetRenderDevice(EquipDevices[i]), libs.GetDeviceKeyword(EquipDevices[i]), SkipMutex = True, SkipEvents = False)
 		Else
 			akActor.EquipItem(EquipDevices[i], abSilent = True)
 		EndIf
@@ -239,7 +239,7 @@ Function RemoveDevices(Actor akActor)
 	While i > 0
 		i -= 1
 		If EquipDevices[i].HasKeyword(libs.zad_InventoryDevice)
-			libs.RemoveDevice(akActor, EquipDevices[i], zadNativeFunctions.GetRenderDevice(EquipDevices[i]) as Armor, libs.GetDeviceKeyword(EquipDevices[i]), SkipMutex = True, SkipEvents = False, DestroyDevice = True)
+			libs.RemoveDevice(akActor, EquipDevices[i], zadNativeFunctions.GetRenderDevice(EquipDevices[i]), libs.GetDeviceKeyword(EquipDevices[i]), SkipMutex = True, SkipEvents = False, DestroyDevice = True)
 		Else
 			akActor.UnEquipItem(EquipDevices[i], abSilent = True)
 			akActor.RemoveItem(EquipDevices[i], abSilent = True)

--- a/dist/scripts/source/zadcFurnitureScript.psc
+++ b/dist/scripts/source/zadcFurnitureScript.psc
@@ -336,7 +336,6 @@ Function LockActor(actor act)
 	EndIf
 	ApplyEffects(user)
 	ApplyDevices(user)	
-	user.AddToFaction(clib.zadcNGInContraptionFaction)
 	user.SetFactionRank(clib.zadcNGInContraptionFaction, 1)
 	RegisterForSingleUpdate(30)	
 	LastBreakEscapeAttemptAt = 0.0
@@ -387,7 +386,6 @@ Function UnlockActor()
 	RemoveEffects(user)
 	clib.ResetNiOverrideOverride(user)
 	RemoveDevices(user)
-	user.SetFactionRank(clib.zadcNGInContraptionFaction, 0)
 	user.RemoveFromFaction(clib.zadcNGInContraptionFaction)
 	;If ForceStripActor			
 	;	clib.RestoreOutfit(user)

--- a/dist/scripts/source/zadcFurnitureScript.psc
+++ b/dist/scripts/source/zadcFurnitureScript.psc
@@ -621,17 +621,16 @@ Bool Function UnlockAttemptNPC()
 		Return False
 	EndIf		
 	If DeviceKey
-		If libs.PlayerRef.GetItemCount(DeviceKey) <= 0
+		Int keyCount = libs.PlayerRef.GetItemCount(DeviceKey)
+		If keyCount <= 0
 			zadc_OnNoKeyMSG.Show()			
 			Return False
-		ElseIf libs.PlayerRef.GetItemCount(DeviceKey) < NumberOfKeysNeeded			
+		ElseIf keyCount < NumberOfKeysNeeded			
 			zadc_OnNotEnoughKeysMSG.Show()			
 			Return False
 		EndIf				
-		If DestroyKey
+		If DestroyKey || (libs.Config.GlobalDestroyKey && DeviceKey.HasKeyword(libs.zad_NonUniqueKey))
 			libs.PlayerRef.RemoveItem(DeviceKey, NumberOfKeysNeeded, False)
-		elseif libs.Config.GlobalDestroyKey && DeviceKey.HasKeyword(libs.zad_NonUniqueKey)
-			libs.PlayerRef.RemoveItem(DeviceKey, NumberOfKeysNeeded, False)	
 		EndIf	
 	EndIf	
 	UnlockActor()
@@ -649,10 +648,11 @@ Bool Function UnlockAttempt()
 		Return False
 	EndIf
 	If DeviceKey
-		If libs.PlayerRef.GetItemCount(DeviceKey) <= 0
+		Int keyCount = libs.PlayerRef.GetItemCount(DeviceKey)
+		If keyCount <= 0
 			zadc_OnNoKeyMSG.Show()			
 			Return False
-		ElseIf libs.PlayerRef.GetItemCount(DeviceKey) < NumberOfKeysNeeded			
+		ElseIf keyCount < NumberOfKeysNeeded			
 			zadc_OnNotEnoughKeysMSG.Show()			
 			Return False
 		EndIf
@@ -661,10 +661,8 @@ Bool Function UnlockAttempt()
 		EndIf		
 		; We show the struggle scene now.
 		StruggleScene(libs.PlayerRef)		
-		If DestroyKey
+		If DestroyKey || (libs.Config.GlobalDestroyKey && DeviceKey.HasKeyword(libs.zad_NonUniqueKey))
 			libs.PlayerRef.RemoveItem(DeviceKey, NumberOfKeysNeeded, False)
-		elseif libs.Config.GlobalDestroyKey && DeviceKey.HasKeyword(libs.zad_NonUniqueKey)
-			libs.PlayerRef.RemoveItem(DeviceKey, NumberOfKeysNeeded, False)	
 		EndIf	
 	Else 
 		If !CheckLockAccess()
@@ -703,7 +701,7 @@ Event OnActivate(ObjectReference akActionRef)
 				LockActor(act)
 			EndIf
 		EndIf
-	Elseif user
+	Else
 		; device is occupied
 		If user != act
 			; someone else is releasing the occupant.
@@ -797,7 +795,7 @@ Event OnUpdate()
 			EndIf
 		EndIf
 		; Since the struggle scene is long, there's a chance user got unlocked since the previous "if user" check. Re-check.
-		if user && !clib.IsAnimating(user)
+		if !clib.IsAnimating(user)
 			; to make up for not checking here, we do when a scene ends.
 			CheckSelfBondageRelease()		
 		EndIf
@@ -904,12 +902,9 @@ Bool Function SexScene(Actor Partner, String AnimationName = "")
 	;		MoveToBehind(self, Partner, Distance)
 	;	EndIf	
 	
-	sslBaseAnimation[] Sanims	
-	Sanims = New sslBaseAnimation[1]
-	String ani
-	If AnimationName != ""
-		ani = AnimationName
-	Else
+	sslBaseAnimation[] Sanims = New sslBaseAnimation[1]
+	String ani = AnimationName
+	If ani == ""
 		ani = PickRandomSexScene()
 	EndIf	
 	if ani != ""
@@ -930,7 +925,7 @@ Bool Function SexScene(Actor Partner, String AnimationName = "")
 		SceneSexActors[1] = Partner	
 		RegisterForModEvent("HookAnimationEnd_DDCEnd", "OnDDCSLEnd")    
 		ActorUtil.RemovePackageOverride(User, CurrentPose)	; otherwise the anims go awry - krzp	
-		If SKSE.GetPluginVersion("SexLabUtil") >= 34340864
+		If libs.HasPPlus
 			Debug.SendAnimationEvent(User, "IdleForceDefaultState")	; sneaky v2 p+ compatibility to make sure animations start from a default idle, otherwise the first stage on the actor in a contraption didn't play in my tests
 		endif
 		libs.Log("Starting contraption sex scene with " + SceneSexActors[0].GetLeveledActorBase().GetName() + " and "+ SceneSexActors[1].GetLeveledActorBase().GetName() + ".")
@@ -1119,10 +1114,12 @@ Bool Function CanMakeStruggleEscapeAttempt()
 		return True
 	Else
 		Int HoursToWait = Math.Ceiling(HoursNeeded - HoursPassed)
-		If user == libs.playerRef && (HoursNeeded - HoursPassed) >= 1.0
-			libs.notify("You cannot try to struggle out of this device so soon after the last attempt! You can try again in about " + HoursToWait + " hours.", messageBox = true)
-		elseIf user == libs.playerRef && (HoursNeeded - HoursPassed) < 1.0
-			libs.notify("You cannot try to struggle out of this device so soon after the last attempt! You can try again very shortly!", messageBox = true)
+		If user == libs.playerRef
+			If (HoursNeeded - HoursPassed) >= 1.0
+				libs.notify("You cannot try to struggle out of this device so soon after the last attempt! You can try again in about " + HoursToWait + " hours.", messageBox = true)
+			else
+				libs.notify("You cannot try to struggle out of this device so soon after the last attempt! You can try again very shortly!", messageBox = true)
+			EndIf
 		Else
 			libs.notify("You cannot help " + user.GetLeveledActorBase().GetName() + " struggle out of their device so soon after the last attempt! You can try again in about " + HoursToWait + " hours.", messageBox = true)
 		EndIf
@@ -1139,10 +1136,12 @@ Bool Function CanMakeBreakEscapeAttempt()
 		return True
 	Else
 		Int HoursToWait = Math.Ceiling(HoursNeeded - HoursPassed)
-		If user == libs.playerRef && (HoursNeeded - HoursPassed) >= 1.0
-			libs.notify("You cannot try to break open this device so soon after the last attempt! You can try again in about " + HoursToWait + " hours.", messageBox = true)
-		elseIf user == libs.playerRef && (HoursNeeded - HoursPassed) < 1.0
-			libs.notify("You cannot try to break open this device so soon after the last attempt! You can try again very shortly!", messageBox = true)
+		If user == libs.playerRef
+			If (HoursNeeded - HoursPassed) >= 1.0
+				libs.notify("You cannot try to break open this device so soon after the last attempt! You can try again in about " + HoursToWait + " hours.", messageBox = true)
+			else
+				libs.notify("You cannot try to break open this device so soon after the last attempt! You can try again very shortly!", messageBox = true)
+			EndIf
 		Else
 			libs.notify("You cannot help " + user.GetLeveledActorBase().GetName() + " to try breaking open this device so soon after the last attempt! You can try again in about " + HoursToWait + " hours.", messageBox = true)
 		EndIf
@@ -1159,10 +1158,12 @@ Bool Function CanMakeLockPickEscapeAttempt()
 		return True
 	Else
 		Int HoursToWait = Math.Ceiling(HoursNeeded - HoursPassed)
-		If user == libs.playerRef && (HoursNeeded - HoursPassed) >= 1.0
-			libs.notify("You cannot try to pick this device so soon after the last attempt! You can try again in about " + HoursToWait + " hours.", messageBox = true)
-		elseIf user == libs.playerRef && (HoursNeeded - HoursPassed) < 1.0
-			libs.notify("You cannot try to pick this device so soon after the last attempt! You can try again very shortly!", messageBox = true)
+		If user == libs.playerRef
+			If (HoursNeeded - HoursPassed) >= 1.0
+				libs.notify("You cannot try to pick this device so soon after the last attempt! You can try again in about " + HoursToWait + " hours.", messageBox = true)
+			else
+				libs.notify("You cannot try to pick this device so soon after the last attempt! You can try again very shortly!", messageBox = true)
+			EndIf
 		Else
 			libs.notify("You cannot help " + user.GetLeveledActorBase().GetName() + " try to pick this device so soon after the last attempt! You can try again in about " + HoursToWait + " hours.", messageBox = true)
 		EndIf
@@ -1265,28 +1266,24 @@ Float Function CalclulateStruggleSuccess()
 	If BaseEscapeChance > 0.0
 		; add 1% for every previous attempt
 		result += EscapeStruggleAttemptsMade		
+		Float akStamina = Libs.PlayerRef.GetActorValue("Stamina")
 		; apply strength bonus
-		If Libs.PlayerRef.GetActorValue("Stamina") > 25 
-			result += 1.0
-		Endif
-		If Libs.PlayerRef.GetActorValue("Stamina") > 50
-			result += 2.0
-		Endif
-		If Libs.PlayerRef.GetActorValue("Stamina") > 75 
+		If akStamina > 75
+			result += 6.0
+		ElseIf akStamina > 50
 			result += 3.0
-		Endif		
+		ElseIf akStamina > 25
+			result += 1.0
+		Endif
 		; apply bonus for total successful escapes - shares that value with wearable restraints
-		Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue() as Int
-		If EscapesMade > 10
-			result += 1.0
-		Endif
-		If EscapesMade > 25
-			result += 1.0
-		Endif
-		If EscapesMade > 50
-			result += 1.0
-		Endif
+		Float EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue()
 		If EscapesMade > 100
+			result += 4.0
+		ElseIf EscapesMade > 50
+			result += 3.0
+		ElseIf EscapesMade > 25
+			result += 2.0
+		ElseIf EscapesMade > 10
 			result += 1.0
 		Endif
 	Endif
@@ -1334,27 +1331,26 @@ Float Function CalclulateBreakSuccess()
 	If BreakDeviceEscapeChance > 0.0
 		; add 1% for every previous attempt
 		result += EscapeBreakAttemptsMade		
-		If Libs.PlayerRef.GetActorValue("OneHanded") > 25 || Libs.PlayerRef.GetActorValue("TwoHanded") > 25
+		Float akOneHanded = Libs.PlayerRef.GetActorValue("OneHanded")
+		Float akTwoHanded = Libs.PlayerRef.GetActorValue("TwoHanded")
+		If akOneHanded > 25 || akTwoHanded > 25
 			result += 1.0
 		Endif
-		If Libs.PlayerRef.GetActorValue("OneHanded") > 50 || Libs.PlayerRef.GetActorValue("TwoHanded") > 50
+		If akOneHanded > 50 || akTwoHanded > 50
 			result += 2.0
 		Endif
-		If Libs.PlayerRef.GetActorValue("OneHanded") > 75 || Libs.PlayerRef.GetActorValue("TwoHanded") > 75
+		If akOneHanded > 75 || akTwoHanded > 75
 			result += 3.0
 		Endif
 		; apply bonus for total successful escapes
-		Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue() as Int
-		If EscapesMade > 10
-			result += 1.0
-		Endif
-		If EscapesMade > 25
-			result += 1.0
-		Endif
-		If EscapesMade > 50
-			result += 1.0
-		Endif
+		Float EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue()
 		If EscapesMade > 100
+			result += 4.0
+		ElseIf EscapesMade > 50
+			result += 3.0
+		ElseIf EscapesMade > 25
+			result += 2.0
+		ElseIf EscapesMade > 10
 			result += 1.0
 		Endif
 	Endif
@@ -1409,37 +1405,35 @@ Function EscapeAttemptLockPick()
 EndFunction
 
 Bool Function HasValidLockPick()
-	Bool HasValidItem = false
 	If AllowLockPick && libs.PlayerRef.GetItemCount(libs.Lockpick) > 0
 		return true
 	EndIf
 	Int i = AllowedLockPicks.Length
-	While i > 0 && !HasValidItem
+	While i > 0
 		i -= 1
 		Form frm = AllowedLockPicks[i]
 		If libs.playerRef.GetItemCount(frm) > 0
-			HasValidItem = True
+			return True
 		EndIf
 	EndWhile
-	return HasValidItem
+	return false
 EndFunction
 
 Bool Function DestroyLockPick()
-	Bool LockPickDestroyed = false
 	If AllowLockPick && libs.PlayerRef.GetItemCount(libs.Lockpick) > 0
 		libs.playerRef.RemoveItem(libs.Lockpick)
 		return True
 	EndIf
 	Int i = AllowedLockPicks.Length
-	While i > 0 && !LockPickDestroyed
+	While i > 0
 		i -= 1
 		Form frm = AllowedLockPicks[i]
-		If libs.playerRef.GetItemCount(frm) > 0 && !(frm As Keyword)
+		If !(frm As Keyword) && libs.playerRef.GetItemCount(frm) > 0
 			libs.playerRef.RemoveItem(frm)
-			LockPickDestroyed = True
+			return True
 		EndIf
 	EndWhile
-	return LockPickDestroyed
+	return false
 EndFunction
 
 Float Function CalclulateLockPickSuccess()
@@ -1448,27 +1442,23 @@ Float Function CalclulateLockPickSuccess()
 	If LockPickEscapeChance > 0.0
 		; add 1% for every previous attempt
 		result += EscapeLockPickAttemptsMade		
-		If Libs.PlayerRef.GetActorValue("Lockpicking") > 25
-			result += 1.0
-		Endif
-		If Libs.PlayerRef.GetActorValue("Lockpicking") > 50
-			result += 2.0
-		Endif
-		If Libs.PlayerRef.GetActorValue("Lockpicking") > 75
+		Float akLockpick = Libs.PlayerRef.GetActorValue("Lockpicking")
+		If akLockpick > 75
+			result += 6.0
+		ElseIf akLockpick > 50
 			result += 3.0
+		ElseIf akLockpick > 25
+			result += 1.0
 		Endif
 		; apply bonus for total successful escapes
-		Int EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue() as Int
-		If EscapesMade > 10
-			result += 1.0
-		Endif
-		If EscapesMade > 25
-			result += 1.0
-		Endif
-		If EscapesMade > 50
-			result += 1.0
-		Endif
+		Float EscapesMade = libs.zadDeviceEscapeSuccessCount.GetValue()
 		If EscapesMade > 100
+			result += 4.0
+		ElseIf EscapesMade > 50
+			result += 3.0
+		ElseIf EscapesMade > 25
+			result += 2.0
+		ElseIf EscapesMade > 10
 			result += 1.0
 		Endif
 	Endif

--- a/dist/scripts/source/zadcNGEscapeMinigame.psc
+++ b/dist/scripts/source/zadcNGEscapeMinigame.psc
@@ -372,7 +372,7 @@ Function Progress()
 EndFunction
 
 Function SlotAppropriateSounds()
-	If PlayerRef.GetActorBase().GetSex() == 0
+	If (PlayerRef.GetBaseObject() as ActorBase).GetSex() == 0
 		gruntMild = zadNG_GruntMaleMild
 		gruntFrustrated = zadNG_GruntMaleFrustrated
 		pantMild = zadNG_PantMaleMild

--- a/dist/scripts/source/zadclibs.psc
+++ b/dist/scripts/source/zadclibs.psc
@@ -404,7 +404,7 @@ Function Test()
 	return
 	ObjectReference objr = Game.GetCurrentCrosshairRef()	
 	Actor act = objr As Actor	
-	If act && act == Game.GetPlayer()		
+	If act == libs.PlayerRef
 		; sanity check
 		return
 	EndIf	
@@ -432,7 +432,7 @@ EndFunction
 Function FurnitureActionV2(Bool AllowActorInScene = false)
 	ObjectReference objr = Game.GetCurrentCrosshairRef()
 	Actor act = objr As Actor	
-	If act && act == Game.GetPlayer()		
+	If act == libs.PlayerRef
 		; sanity check
 		return
 	EndIf	
@@ -456,7 +456,7 @@ Function FurnitureActionV2(Bool AllowActorInScene = false)
 			; yes, display the unlock NPC dialogue
 			debug.notification("Freeing " + act.GetActorBase().GetName())
 			; sending the player as operator, so the furniture script can tell freeing the user apart from an escape attempt!
-			obj.Activate(Game.GetPlayer())
+			obj.Activate(libs.PlayerRef)
 			return
 		EndIf
 		If !SelectedUser				

--- a/dist/scripts/source/zadclibs.psc
+++ b/dist/scripts/source/zadclibs.psc
@@ -71,10 +71,7 @@ MiscObject Property zadc_kit_xcross Auto
 
 ; Checks if the given reference is a DDC furniture device
 Bool Function GetIsFurnitureDevice(ObjectReference FurnitureDevice)
-	If FurnitureDevice && FurnitureDevice.HasKeyword(zadc_FurnitureDevice)
-		return True
-	EndIf
-	return False
+	return FurnitureDevice && FurnitureDevice.HasKeyword(zadc_FurnitureDevice)
 EndFunction
 
 ; Returns the actor currently locked in a given device (or none if not a valid furniture device, or if it's not occupied)
@@ -133,12 +130,9 @@ EndFunction
 ; Retrieves the furniture device closest to the player, if there is any in the active cell.
 ObjectReference Function GetClosestFurnitureDevice()
 	; need to force re/start the quest to fill the alias
-	if zadc_nearbyfurniture.IsRunning()		
-		zadc_nearbyfurniture.Stop()
-		zadc_nearbyfurniture.Start()
-	Else
-		zadc_nearbyfurniture.Start()
-	EndIf
+	zadc_nearbyfurniture.Stop()
+	zadc_nearbyfurniture.Start()
+
 	ReferenceAlias device = zadc_nearbyfurniture.GetAlias(0) As ReferenceAlias	; That's the only alias in that quest
 	If device
 		Return device.GetReference()
@@ -181,11 +175,7 @@ EndFunction
 
 ; Retrieves the override pose. Returns none if no override pose is set.
 Package Function GetOverridePose(ObjectReference FurnitureDevice)	
-	Package Pose = StorageUtil.GetFormValue(FurnitureDevice, "DDC_OverridePose") As Package
-	If Pose
-		return Pose
-	EndIf
-	Return None
+	return StorageUtil.GetFormValue(FurnitureDevice, "DDC_OverridePose") As Package
 EndFunction
 
 ; clears the override pose
@@ -378,12 +368,12 @@ Event OnKeyDown(Int KeyCode)
 	If UI.IsMenuOpen("Console") || UI.IsMenuOpen("Console Native UI Menu")
 		Return
 	EndIf
-	If (KeyCode == libs.Config.FurnitureNPCActionKey)
-		FurnitureAction()
-	Endif	
-	If (KeyCode == 0xD1) 
-		Test()
-	Endif	
+
+	FurnitureAction()
+
+	;If (KeyCode == 0xD1) 
+	;	Test()
+	;Endif	
 EndEvent
 
 Bool Function GetIsFemale(Actor act)
@@ -415,10 +405,7 @@ EndFunction
 
 ; checks if this person is available for a scene
 bool Function IsAnimating(actor akActor)
-	if akActor.IsOnMount()
-		return True
-	endif
-	return (akActor.IsInFaction(libs.zadAnimatingFaction) || akActor.IsInFaction(libs.Sexlab.AnimatingFaction))
+	return akActor.IsOnMount() || (akActor.IsInFaction(libs.zadAnimatingFaction) || akActor.IsInFaction(libs.Sexlab.AnimatingFaction))
 EndFunction
 
 ; Parameters are persitant in pex files. 2-stage function call to avoid breaking older mods.

--- a/dist/scripts/source/zadclibs.psc
+++ b/dist/scripts/source/zadclibs.psc
@@ -186,7 +186,7 @@ EndFunction
 ; Sets the timed release for a given device to x hours and activates the auto-release feature. This can also be used to renew the timer by passing ResetStartTime = True.
 ; Mind you that these settings may be overriden if the player is able to use the dialogue to place herself or an NPC in the device -after- this
 ; function was called, but she cannot after the subject was placed in the device. Use it accordingly.
-Bool Function SetTimedRelease(ObjectReference FurnitureDevice, Int Hours, Bool ResetStartTime = False)
+Function SetTimedRelease(ObjectReference FurnitureDevice, Int Hours, Bool ResetStartTime = False)
 	zadcFurnitureScript fs = FurnitureDevice as zadcFurnitureScript
 	if fs 
 		fs.isSelfBondage = True
@@ -226,7 +226,7 @@ Bool Function LockActorV2(Actor akActor, ObjectReference FurnitureDevice, Packag
 EndFunction
 
 ; Unlock an actor. This bypasses all checks normally performed (e.g. keys or lock shields)
-Bool Function UnlockActor(Actor akActor)
+Function UnlockActor(Actor akActor)
 	zadcFurnitureScript fs = GetDevice(akActor) as zadcFurnitureScript
 	if fs && fs.User		
 		fs.UnlockActor()		
@@ -432,18 +432,18 @@ Function FurnitureActionV2(Bool AllowActorInScene = false)
 			debug.notification("This device is occupied.")				
 		EndIf
 	EndIf
-	If objr.HasKeyword(zadc_FurnitureDevice) && !SelectedUser
+	;If objr.HasKeyword(zadc_FurnitureDevice) && !SelectedUser
 		; no actor selected, so we can manipulate the device instead!
 		
-	EndIf
+	;EndIf
 	If act
 		; Is the target locked in a device?
-		ObjectReference obj = GetDevice(act)
-		If obj
+		objr = GetDevice(act)
+		If objr
 			; yes, display the unlock NPC dialogue
 			debug.notification("Freeing " + act.GetActorBase().GetName())
 			; sending the player as operator, so the furniture script can tell freeing the user apart from an escape attempt!
-			obj.Activate(libs.PlayerRef)
+			objr.Activate(libs.PlayerRef)
 			return
 		EndIf
 		If !SelectedUser				

--- a/dist/scripts/source/zadexpressionlibs.psc
+++ b/dist/scripts/source/zadexpressionlibs.psc
@@ -249,7 +249,6 @@ EndFunction
 ;sometimes look stupid, other times look good. Depends on luck :)
 Float[] Function CreateRandomExpression() global
     float[] loc_expression      = CreateEmptyExpression()
-    string  loc_strres          = ""
     int     loc_i               = 0
 
     while loc_i < loc_expression.length - 2

--- a/dist/scripts/source/zadexpressionlibs.psc
+++ b/dist/scripts/source/zadexpressionlibs.psc
@@ -126,7 +126,7 @@ endProperty
 
 ;round float number and returns int
 Int Function Round(Float afValue) global
-    return Math.Floor(afValue + 0.5)
+    return (afValue + 0.5) as Int
 EndFunction
 
 ;returns empty expression float array
@@ -265,7 +265,7 @@ EndFunction
 
 ;check current gag state and update phonems 
 Function ApplyGagEffect(actor akActor)
-    if akActor.Is3DLoaded() || akActor == Game.getPlayer()
+    if akActor.Is3DLoaded() || akActor == libs.PlayerRef
         ;Check custom gag expressions first before mutex is applied
         If akActor.WornHasKeyword(libs.zad_GagCustomExpression)
             libs.SendGagEffectEvent(akActor, false)

--- a/dist/scripts/source/zadexpressionlibs.psc
+++ b/dist/scripts/source/zadexpressionlibs.psc
@@ -126,7 +126,7 @@ endProperty
 
 ;round float number and returns int
 Int Function Round(Float afValue) global
-    return (afValue + 0.5) as Int
+    return Math.Floor(afValue + 0.5)
 EndFunction
 
 ;returns empty expression float array

--- a/dist/scripts/source/zadx_BondageMittensEffectScript.psc
+++ b/dist/scripts/source/zadx_BondageMittensEffectScript.psc
@@ -3,20 +3,6 @@ Scriptname zadx_BondageMittensEffectScript extends activemagiceffect
 zadlibs Property libs  Auto
 
 Armor Property zad_DeviceHider Auto
-bool Function isDeviousDevice(Form device)
-    if device.HasKeyword(libs.zad_InventoryDevice) || device.HasKeyword(libs.zad_Lockable) 
-        return true
-    endif
-    return false
-EndFunction
-
-bool Function isValidItem(Form item)
-    ; the device hider is not tagged with a DD keyword, so we need to explicitly rule it out.
-    If item.GetName() && (item.GetType() == 41 || (item.GetType() == 26 && !isDeviousDevice(Item)) || item.GetType() == 45)
-        return true
-    EndIf
-    return false
-EndFunction
 
 Event OnEffectStart(Actor akTarget, Actor akCaster)
     if akTarget != libs.playerRef

--- a/dist/scripts/source/zadx_ForcedWalkScript.psc
+++ b/dist/scripts/source/zadx_ForcedWalkScript.psc
@@ -2,10 +2,6 @@ Scriptname zadx_ForcedWalkScript extends activemagiceffect
 
 zadLibs Property Libs Auto
 
-string savedMSG1
-string savedMSG2
-bool savedINIDampen
-
 Event OnEffectStart(Actor akTarget, Actor akCaster)
 EndEvent
 

--- a/dist/scripts/source/zadx_GagInflatableScript.psc
+++ b/dist/scripts/source/zadx_GagInflatableScript.psc
@@ -37,18 +37,20 @@ Function DeviceMenuExt(int msgChoice)
 	ElseIf msgChoice == 4 ; Inflate gag
 		InflateGag(gagwearer)
 	ElseIf msgChoice == 5 ; Deflate gag
-		if deviceValveKey && libs.PlayerRef.GetItemCount(deviceValveKey) == 0
-			libs.NotifyPlayer("You lack the key to manipulate the valve.")
-		elseif deviceValveKey && libs.PlayerRef.GetItemCount(deviceValveKey) >= 0
-			DeflateGag(gagwearer)
-			If DestroyValveKey && deviceValveKey.HasKeyword(libs.zad_NonUniqueKey)
-				libs.PlayerRef.RemoveItem(deviceValveKey, 1, False)
-			elseif libs.Config.GlobalDestroyKey && deviceValveKey.HasKeyword(libs.zad_NonUniqueKey)
-				libs.PlayerRef.RemoveItem(deviceValveKey, 1, False)
+		if deviceValveKey
+			if libs.PlayerRef.GetItemCount(deviceValveKey) == 0
+				libs.NotifyPlayer("You lack the key to manipulate the valve.")
+			else
+				DeflateGag(gagwearer)
+				If (DestroyValveKey || libs.Config.GlobalDestroyKey) && deviceValveKey.HasKeyword(libs.zad_NonUniqueKey)
+					libs.PlayerRef.RemoveItem(deviceValveKey, 1, False)
+				endif
 			endif
-		else
-			DeflateGag(gagwearer)
+
+			Return
 		endif
+
+		DeflateGag(gagwearer)
 	EndIf
 EndFunction
 

--- a/dist/scripts/source/zadx_GagInflatableScript.psc
+++ b/dist/scripts/source/zadx_GagInflatableScript.psc
@@ -11,14 +11,12 @@ int inflationFactionRank
 
 Function OnEquippedPre(actor akActor, bool silent=false)
 	libs.Log("Inflatable Gag: Setting faction rank.")
-	akActor.AddToFaction(zadx_InflatableGagFaction)
 	akActor.SetFactionRank(zadx_InflatableGagFaction, 1)
 	Parent.OnEquippedPre(akActor, silent)
 EndFunction
 
 Function OnRemoveDevice(actor akActor)
 	libs.Log("Inflatable Gag: Resetting faction rank.")
-	akActor.SetFactionRank(zadx_InflatableGagFaction, 0)
 	akActor.RemoveFromFaction(zadx_InflatableGagFaction)
 EndFunction
 

--- a/dist/scripts/source/zadx_HobbleSkirtEffectScript.psc
+++ b/dist/scripts/source/zadx_HobbleSkirtEffectScript.psc
@@ -15,7 +15,7 @@ float REQSavedVal				;Saved value of the setting, returned once the dress is une
 
 bool Function GetRequiem()
 	If Game.GetModByName("Requiem.esp") != 255
-		REQExhaustion = (Game.GetFormFromFile(0x0336AD6A, "Requiem.esp") as GlobalVariable)
+		REQExhaustion = (Game.GetFormFromFile(0x36AD6A, "Requiem.esp") as GlobalVariable)
 		libs.Log("GetRequiem(): Hobble Skirt == true. Switching to Requiem compatibility mode.")
 		return True
 	Else

--- a/dist/scripts/source/zadx_HobbleSkirtEffectScript.psc
+++ b/dist/scripts/source/zadx_HobbleSkirtEffectScript.psc
@@ -31,8 +31,8 @@ bool Function GetRequiem()
 EndFunction
 
 Function ApplySM(actor akTarget)
-	akTarget.DamageAv("CarryWeight", 0.02)
-	akTarget.RestoreAv("CarryWeight", 0.02)
+	akTarget.DamageActorValue("CarryWeight", 0.02)
+	akTarget.RestoreActorValue("CarryWeight", 0.02)
 EndFunction
 
 Event OnEffectStart(Actor akTarget, Actor akCaster)

--- a/dist/scripts/source/zadx_HobbleSkirtEffectScript.psc
+++ b/dist/scripts/source/zadx_HobbleSkirtEffectScript.psc
@@ -3,17 +3,10 @@ ScriptName zadx_HobbleSkirtEffectScript extends ActiveMagicEffect
 ; Libraries
 zadLibs Property Libs Auto
 
-Float SpeedMultDifferential = 0.0
-Float TargetSpeedMult = 50.0
-Float FlatSpeedDebuff = 50.0
-Float SpeedMultRestore = 0.0
-
-bool savedINIDampen
-bool FootIKneedsreset
 bool MuJointFixneedsreset
 
-String Property NINODE_ROOT = "NPC" AutoReadOnly
-String Property NIOO_KEY = "DDPET" AutoReadOnly
+String Property NINODE_ROOT = "NPC" AutoReadOnly Hidden
+String Property NIOO_KEY = "DDPET" AutoReadOnly Hidden
 
 Actor who
 Keyword Property zad_DeviousHobbleSkirtRelaxed Auto	;extreme or relaxed speed debuff


### PR DESCRIPTION
This is largely micro and script optimizations with bug fixes that were found during the process. I did multiple look overs of each script. I good portion of the changes I've made are things I've been privately using for a long time, and am just finally forwarding here. I split the changes into separate commits.

**Bug Fixes:**
- Fix a bug where the catsuit event would trigger indoor events outside, and outdoor events inside.
- Fix a case where it was possible for a function to be called on a None object.

**Optimizations:**
- Micro optimizations
- Redundant function calls: 
AddToFaction before SetFactionRank (SetFactionRank handles add to faction internally.)
SetFactionRank before RemoveFromFaction (RemoveFromFaction handles set faction rank before removing, actors not in a faction return -2.)
- Code Optimizations: I rewrote pieces of code to make less function calls.
- Unused code: I looked over scripts and removed unused variables. I also added the Hidden flag to properties that aren't filled in the CK (although I likely missed some instances when skimming.)

**Methodology For Micro Optimizations:**
The methodology behind these are based on [Papyrus Speed Test](https://www.nexusmods.com/skyrim/mods/18825) tests.
Nexusmods [Vanilla Script (micro)Optimizations](https://www.nexusmods.com/skyrimspecialedition/mods/54061) follows the same idea.
Specific papyrus functions are FPS hooked. They always take 1 frame to complete (16.6ms~ @ 60FPS.) Game.GetPlayer() is a well known example.
The papyrus compiler has no concept of inline functions. This means convenience and helper functions are slower than calling the native function itself. This is because you're really calling a function of a function, instead of the function itself.

```
GlobalVariable SetValueInt -> SetValue
GlobalVariable GetValueInt() -> GetValue() as Int
Actor GetAV -> GetActorValue
ReferenceAlias GetActorReference -> GetReference() as Actor
```